### PR TITLE
add: manage layout and basic functionality

### DIFF
--- a/frontend/src/Routes.js
+++ b/frontend/src/Routes.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Main from './pages/Main';
 import Signup from './pages/Signup';
+import Manage from './pages/Manage';
 
 function Router() {
   return (
@@ -9,6 +10,7 @@ function Router() {
       <Routes>
         <Route path="/" element={<Main />} />
         <Route path="/signup" element={<Signup />} />
+        <Route path="/manage" element={<Manage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Manage.js
+++ b/frontend/src/pages/Manage.js
@@ -1,14 +1,65 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 
 import HeaderAndTitle from '../components/HeaderAndTitle';
+import theme from '../styles/Theme';
 
 const pixelToRem = size => `${size / 16}rem`;
 
+// 외부적으로 해야 할 일
+// Title > TitleContainer > Icon > FontAwesomeIcon 변경 가능하도록 파라미터화
+
 function Manage(props) {
+  const pageRef = React.createRef();
+  const headerRef = React.createRef();
+  const selectTab = data => {
+    const pages = pageRef.current.children;
+    const headers = headerRef.current.children;
+    const len = pages.length;
+
+    const hiddenTag = 'hidden-page';
+    for (let i = 0; i < len; i++) {
+      if (data.target === headers[i]) {
+        // matching page index === i
+        for (let j = 0; j < len; j++) {
+          if (i === j && pages[j].classList.contains(hiddenTag)) {
+            pages[j].classList.remove(hiddenTag);
+          } else if (
+            i !== j &&
+            pages[j].classList.contains(hiddenTag) === false
+          ) {
+            pages[j].classList.add(hiddenTag);
+          }
+        }
+      }
+    }
+
+    console.log('end of function');
+  };
   return (
     <ManageContainer>
       <HeaderAndTitle titleName="관리" />
+      <ManageTabHeaderContainer ref={headerRef}>
+        <ManageTabHeaderItem onClick={selectTab}>회원 승인</ManageTabHeaderItem>
+        <ManageTabHeaderItem onClick={selectTab}>회원 정보</ManageTabHeaderItem>
+        <ManageTabHeaderItem onClick={selectTab}>우산 대여</ManageTabHeaderItem>
+        <ManageTabHeaderItem onClick={selectTab}>
+          사물함 대여
+        </ManageTabHeaderItem>
+      </ManageTabHeaderContainer>
+      <ManageTabPageContainer ref={pageRef}>
+        <ManageTabPageItem>회원 승인 컴포넌트</ManageTabPageItem>
+        <ManageTabPageItem className="hidden-page">
+          회원 정보 컴포넌트
+        </ManageTabPageItem>
+        <ManageTabPageItem className="hidden-page">
+          우산 대여 컴포넌트
+        </ManageTabPageItem>
+        <ManageTabPageItem className="hidden-page">
+          사물함 대여 컴포넌트
+        </ManageTabPageItem>
+      </ManageTabPageContainer>
     </ManageContainer>
   );
 }
@@ -18,4 +69,39 @@ export default Manage;
 const ManageContainer = styled.div`
   width: 100%;
   height: 100vh;
+`;
+
+const ManageTabHeaderContainer = styled.ul`
+  height: 40px;
+  list-style: none;
+  display: block;
+  float: none;
+  clear: both;
+  margin: 0 ${pixelToRem(40)};
+  padding-left: ${pixelToRem(71)};
+  border-bottom: 2px solid ${theme.colors.light_grey};
+`;
+
+const ManageTabHeaderItem = styled.div`
+  width: 100px;
+  height: 40px;
+  float: left;
+  text-align: center;
+  text-decoration: none;
+  border: 1px solid white;
+`;
+
+const ManageTabPageContainer = styled.div`
+  display: block;
+  margin: 0 ${pixelToRem(40)};
+  padding-left: ${pixelToRem(71)};
+  border-bottom: 2px solid ${theme.colors.light_grey};
+
+  .hidden-page {
+    display: none;
+  }
+`;
+
+const ManageTabPageItem = styled.div`
+  background-color: transparent;
 `;

--- a/frontend/src/pages/Manage.js
+++ b/frontend/src/pages/Manage.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import HeaderAndTitle from '../components/HeaderAndTitle';
+
+const pixelToRem = size => `${size / 16}rem`;
+
+function Manage(props) {
+  return (
+    <ManageContainer>
+      <HeaderAndTitle titleName="관리" />
+    </ManageContainer>
+  );
+}
+
+export default Manage;
+
+const ManageContainer = styled.div`
+  width: 100%;
+  height: 100vh;
+`;

--- a/frontend/src/pages/Manage.js
+++ b/frontend/src/pages/Manage.js
@@ -68,34 +68,35 @@ export default Manage;
 
 const ManageContainer = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `;
 
 const ManageTabHeaderContainer = styled.ul`
-  height: 40px;
-  list-style: none;
   display: block;
+  list-style: none;
   float: none;
   clear: both;
-  margin: 0 ${pixelToRem(40)};
-  padding-left: ${pixelToRem(71)};
+  height: ${pixelToRem(40)};
   border-bottom: 2px solid ${theme.colors.light_grey};
+  padding-left: ${pixelToRem(71)};
+  margin: 0 ${pixelToRem(40)};
 `;
 
 const ManageTabHeaderItem = styled.div`
-  width: 100px;
-  height: 40px;
+  line-height: ${pixelToRem(40)};
   float: left;
+  width: ${pixelToRem(100)};
+  height: ${pixelToRem(40)};
+  border: 1px solid gray;
   text-align: center;
   text-decoration: none;
-  border: 1px solid white;
 `;
 
 const ManageTabPageContainer = styled.div`
   display: block;
-  margin: 0 ${pixelToRem(40)};
-  padding-left: ${pixelToRem(71)};
   border-bottom: 2px solid ${theme.colors.light_grey};
+  padding-left: ${pixelToRem(71)};
+  margin: 0 ${pixelToRem(40)};
 
   .hidden-page {
     display: none;


### PR DESCRIPTION
# 관리 페이지 최초 생성 및 레이아웃 작업

## 주요 변경 내용
- `src/pages/manage.js` 생성 및 route에 링크 추가 (`/manage`)
- 탭 4개 생성(회원 승인, 회원 정보, 우산 대여, 사물함 대여) 및 탭 제목 클릭 시 컴포넌트 디스플레이 전환

## 참고 사항
- 차후 세부 컴포넌트를 개발할 때, `<ManageTabPageItem>`을 삭제하고 해당 컴포넌트로 변경해서 개발하면 됩니다.
- className으로 `hidden-page`를 추가했습니다. 해당 이름이 추가되면 표현이 되지 않습니다.
  - 클릭하는 탭 제목의 번호과 동일한 순서대로의 컴포넌트만을 제외하고 다른 페이지 컴포넌트에 자동적으로 추가됩니다.
  - 예를 들어, 3번째`<ManageTabHeaderItem>`를 클릭했다면 `<ManageTabPageContainer>`의 3번째 자식 컴포넌트를 제외한 모든 컴포넌트에 `hidden-page`가 추가됩니다. 컴포넌트의 태그 이름은 무관합니다.

## 남은 작업 내용
- (Backend) Backend 연결이 필요하며, 회장 열람 여부에 따라 보여주는 탭의 내용이 바뀌어야 합니다.
- (Frontend) Css 작업 및 디자인 개선이 필요합니다.

## 참고용 시연 사진
![image](https://user-images.githubusercontent.com/39708748/219321403-97ea7059-d2e5-45bb-b23a-0f91e09ecd0b.png)
![image](https://user-images.githubusercontent.com/39708748/219322293-2dd680ba-4f01-47d6-9988-ffda3e187c57.png)

