### PR TITLE
feat: Implement Login system from dummy data

### DIFF
--- a/frontend/public/memberInfo.json
+++ b/frontend/public/memberInfo.json
@@ -1,20 +1,20 @@
 {
   "memberInfo": [
-    {"nickname": "apple", "name": "이지우", "studentID": 22,
+    {"ID": "C211000", "nickname": "apple", "name": "이지우", "studentID": 22,
       "schoolGrade": 2, "major": "컴퓨터공학전공", "tel": "010-1234-5678", "grade": "president"},
-    {"nickname": "banana", "name": "경수현", "studentID": 20,
+    {"ID": "C031000", "nickname": "banana", "name": "경수현", "studentID": 20,
       "schoolGrade": 4, "major": "경영학전공", "tel": "010-1234-5678", "grade": "manager"},
-    {"nickname": "pineapple", "name": "김진호", "studentID": 17,
+    {"ID": "B731000", "nickname": "pineapple", "name": "김진호", "studentID": 17,
       "schoolGrade": 5, "major": "경영학전공", "tel": "010-1234-5678", "grade": "manager"},
-    {"nickname": "melon", "name": "김효진", "studentID": 21,
+    {"ID": "C119000", "nickname": "melon", "name": "김효진", "studentID": 21,
       "schoolGrade": 2, "major": "신소재공학전공", "tel": "010-1234-5678", "grade": "manager"},
-    {"nickname": "strawberry", "name": "김화윤", "studentID": 22,
+    {"ID": "C219000", "nickname": "strawberry", "name": "김화윤", "studentID": 22,
       "schoolGrade": 2, "major": "신소재공학전공", "tel": "010-1234-5678", "grade": "manager"},
-    {"nickname": "orange", "name": "장민지", "studentID": 22,
+    {"ID": "C211000", "nickname": "orange", "name": "장민지", "studentID": 22,
       "schoolGrade": 2, "major": "컴퓨터공학전공", "tel": "010-1234-5678", "grade": "manager"},
-    {"nickname": "pear", "name": "윤찬호", "studentID": 19,
+    {"ID": "B915000", "nickname": "pear", "name": "윤찬호", "studentID": 19,
       "schoolGrade": 3, "major": "컴퓨터공학전공", "tel": "010-1234-5678", "grade": "normal"},
-    {"nickname": "peach", "name": "김준호", "studentID": 20,
+    {"ID": "C015000", "nickname": "peach", "name": "김준호", "studentID": 20,
       "schoolGrade": 3, "major": "전자전기공학부", "tel": "010-1234-5678", "grade": "normal"}
   ]
 }

--- a/frontend/src/_actions/types.js
+++ b/frontend/src/_actions/types.js
@@ -1,4 +1,6 @@
 export const REGISTER_USER = 'REGISTER_USER';
+export const LOGIN_USER = 'LOGIN_USER';
+export const LOGOUT_USER = 'LOGOUT_USER';
 export const INIT_MEMBER = 'INIT_MEMBER';
 export const CHANGE_GRADE = 'CHANGE_GRADE';
 export const DELETE_MEMBER = 'DELETE_MEMBER';

--- a/frontend/src/_actions/userAction.js
+++ b/frontend/src/_actions/userAction.js
@@ -1,4 +1,4 @@
-import { REGISTER_USER } from './types';
+import { LOGIN_USER, LOGOUT_USER, REGISTER_USER } from './types';
 import { request } from '../utils/axios';
 
 const USER_URL = '';
@@ -9,5 +9,19 @@ export function registerUser(data) {
   return {
     type: REGISTER_USER,
     payload: registerData,
+  };
+}
+
+export function loginUser(data) {
+  return {
+    type: LOGIN_USER,
+    payload: data,
+  };
+}
+
+export function logoutUser(data) {
+  return {
+    type: LOGOUT_USER,
+    payload: data,
   };
 }

--- a/frontend/src/_reducers/UserReducer.js
+++ b/frontend/src/_reducers/UserReducer.js
@@ -1,9 +1,13 @@
-import { REGISTER_USER } from '../_actions/types';
+import { LOGIN_USER, LOGOUT_USER, REGISTER_USER } from '../_actions/types';
 
 export default function userReducer(state = {}, action) {
   switch (action.type) {
     case REGISTER_USER:
       return { ...state, registerSuccess: action.payload };
+    case LOGIN_USER:
+      return { ...state, loginSuccess: action.payload };
+    case LOGOUT_USER:
+      return { ...state, logoutSuccess: action.payload };
     default:
       return state;
   }

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -8,6 +8,7 @@ import { faCircleUser } from '@fortawesome/free-regular-svg-icons';
 import SearchWindow from './SearchWindow';
 import UserModal from './UserModal';
 import NoticeModal from './NoticeModal';
+import { Link } from 'react-router-dom';
 
 const pixelToRem = size => `${size / 16}rem`;
 
@@ -34,7 +35,9 @@ export default function Header() {
   });
   return (
     <HeaderContainer>
-      <Logo />
+      <LogoLink to={'/'}>
+        <Logo />
+      </LogoLink>
       <UserContainer>
         <SearchWindow />
         <NoticeButtonWrapper ref={noticeButtonRef}>
@@ -69,6 +72,8 @@ const HeaderContainer = styled.header`
   border-bottom: ${pixelToRem(2)} solid ${theme.colors.light_grey};
   transform: rotate(-0.05deg);
 `;
+
+const LogoLink = styled(Link)``;
 
 const Logo = styled.div`
   width: ${pixelToRem(100)};

--- a/frontend/src/components/LoginUserModal.js
+++ b/frontend/src/components/LoginUserModal.js
@@ -17,10 +17,8 @@ export default function LoginUserModal(props) {
     handleSubmit,
     formState: { errors },
   } = useForm();
-  const dispatch = useDispatch();
   const onSubmit = data => {
-    props.loginRequest(true);
-    dispatch(loginUser(data));
+    props.loginRequest(data);
   };
   return (
     <UserModalContainer>

--- a/frontend/src/components/LoginUserModal.js
+++ b/frontend/src/components/LoginUserModal.js
@@ -6,16 +6,22 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleUser } from '@fortawesome/free-regular-svg-icons';
 import LoginInputMemberInfo from './LoginInputMemberInfo';
 import InputMemberValidInfo from './InputMemberValidInfo';
+import { useDispatch } from 'react-redux';
+import { loginUser } from '../_actions/userAction';
 
 const pixelToRem = size => `${size / 16}rem`;
 
-export default function LoginUserModal() {
+export default function LoginUserModal(props) {
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm();
-  const onSubmit = data => console.log(data);
+  const dispatch = useDispatch();
+  const onSubmit = data => {
+    props.loginRequest(true);
+    dispatch(loginUser(data));
+  };
   return (
     <UserModalContainer>
       <UserModalInner>

--- a/frontend/src/components/LogoutUserModal.js
+++ b/frontend/src/components/LogoutUserModal.js
@@ -8,44 +8,11 @@ import { logoutUser } from '../_actions/userAction';
 
 const pixelToRem = size => `${size / 16}rem`;
 
-const gradeName = {
-  president: '회장',
-  manager: '운영진',
-  normal: '일반',
-  graduate: '졸업생',
-};
-
 export default function LogoutUserModal(props) {
-  const [loginUserID, setLoginUserID] = useState('');
-  const [loginUserNickname, setLoginUserNickname] = useState('');
-  const [loginUserGrade, setLoginUserGrade] = useState('');
-  const authStore = useSelector(state => state.userReducer);
   const dispatch = useDispatch();
-  const fetchData = () => {
-    return fetch('memberInfo.json')
-      .then(res => res.json())
-      .then(data => data.memberInfo);
-  };
-  useEffect(() => {
-    const getMemberInfo = async () => {
-      const result = await fetchData();
-      const user = authStore.loginSuccess;
-      for (const member of result) {
-        if (user.ID === member.ID) {
-          setLoginUserID(user.ID);
-          setLoginUserNickname(member.nickname);
-          const grades = Object.keys(gradeName);
-          const grade = grades.find(key => key === member.grade);
-          setLoginUserGrade(gradeName[grade]);
-          break;
-        }
-      }
-    };
-    getMemberInfo();
-  }, []);
   const logout = () => {
-    props.loginRequest(false);
-    dispatch(logoutUser(loginUserID));
+    dispatch(logoutUser(props.id));
+    props.setAuth(false);
     alert('정상적으로 로그아웃 되었습니다.');
   };
   return (
@@ -54,8 +21,8 @@ export default function LogoutUserModal(props) {
         <UserIcon>
           <FontAwesomeIcon icon={faCircleUser} />
         </UserIcon>
-        <Nickname>{loginUserNickname}</Nickname>
-        <Grade>{loginUserGrade}</Grade>
+        <Nickname>{props.nickname}</Nickname>
+        <Grade>{props.grade}</Grade>
         <ModalInButtonContainer>
           <ModalInButton type="button">정보수정</ModalInButton>
           <ModalInButton type="button">내가 작성한 글/댓글</ModalInButton>

--- a/frontend/src/components/LogoutUserModal.js
+++ b/frontend/src/components/LogoutUserModal.js
@@ -1,26 +1,67 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import theme from '../styles/Theme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleUser } from '@fortawesome/free-regular-svg-icons';
+import { useDispatch, useSelector } from 'react-redux';
+import { logoutUser } from '../_actions/userAction';
 
 const pixelToRem = size => `${size / 16}rem`;
 
-export default function LogoutUserModal() {
+const gradeName = {
+  president: '회장',
+  manager: '운영진',
+  normal: '일반',
+  graduate: '졸업생',
+};
+
+export default function LogoutUserModal(props) {
+  const [loginUserID, setLoginUserID] = useState('');
+  const [loginUserNickname, setLoginUserNickname] = useState('');
+  const [loginUserGrade, setLoginUserGrade] = useState('');
+  const authStore = useSelector(state => state.userReducer);
+  const dispatch = useDispatch();
+  const fetchData = () => {
+    return fetch('memberInfo.json')
+      .then(res => res.json())
+      .then(data => data.memberInfo);
+  };
+  useEffect(() => {
+    const getMemberInfo = async () => {
+      const result = await fetchData();
+      const user = authStore.loginSuccess;
+      for (const member of result) {
+        if (user.ID === member.ID) {
+          setLoginUserID(user.ID);
+          setLoginUserNickname(member.nickname);
+          const grades = Object.keys(gradeName);
+          const grade = grades.find(key => key === member.grade);
+          setLoginUserGrade(gradeName[grade]);
+          break;
+        }
+      }
+    };
+    getMemberInfo();
+  }, []);
+  const logout = () => {
+    props.loginRequest(false);
+    dispatch(logoutUser(loginUserID));
+    alert('정상적으로 로그아웃 되었습니다.');
+  };
   return (
     <LogoutUserModalContainer>
       <LogoutUserModalInner>
         <UserIcon>
           <FontAwesomeIcon icon={faCircleUser} />
         </UserIcon>
-        <Nickname>닉네임</Nickname>
-        <Grade>등급(회장,운영진)</Grade>
+        <Nickname>{loginUserNickname}</Nickname>
+        <Grade>{loginUserGrade}</Grade>
         <ModalInButtonContainer>
           <ModalInButton type="button">정보수정</ModalInButton>
           <ModalInButton type="button">내가 작성한 글/댓글</ModalInButton>
           <ModalInButton type="button">관리페이지</ModalInButton>
         </ModalInButtonContainer>
-        <GoSignupButton href={'/signup'}>로그아웃</GoSignupButton>
+        <LogoutButton onClick={logout}>로그아웃</LogoutButton>
       </LogoutUserModalInner>
     </LogoutUserModalContainer>
   );
@@ -100,11 +141,16 @@ const ModalInButton = styled.button`
   }
 `;
 
-const GoSignupButton = styled.a`
+const LogoutButton = styled.button`
   width: ${pixelToRem(40)};
   height: ${pixelToRem(12)};
   margin-top: ${pixelToRem(5)};
   color: ${theme.colors.blue};
+  background: transparent;
+  border: none;
   font-size: ${theme.fontSizes.font_micro};
   text-decoration-line: none;
+  &:hover {
+    cursor: pointer;
+  }
 `;

--- a/frontend/src/components/UserModal.js
+++ b/frontend/src/components/UserModal.js
@@ -1,15 +1,61 @@
 import React, { useState } from 'react';
 import LoginUserModal from './LoginUserModal';
 import LogoutUserModal from './LogoutUserModal';
+import { useDispatch } from 'react-redux';
+import { loginUser } from '../_actions/userAction';
 
 export default function UserModal() {
-  const [loginRequest, setLoginRequest] = useState(false);
-  const changeLoginRequest = state => {
-    setLoginRequest(state);
+  const [auth, setAuth] = useState(false);
+  const [loginUserID, setLoginUserID] = useState('');
+  const [loginUserNickname, setLoginUserNickname] = useState('');
+  const [loginUserGrade, setLoginUserGrade] = useState('');
+  const dispatch = useDispatch();
+  const loginRequest = data => {
+    // 인증 성공하면
+    authentication(data).then(res => {
+      if (res === true) {
+        dispatch(loginUser(data));
+        setAuth(true);
+      } else {
+        alert('인증 실패');
+      }
+    });
   };
-  return loginRequest ? (
-    <LogoutUserModal loginRequest={changeLoginRequest} />
+  const gradeName = {
+    president: '회장',
+    manager: '운영진',
+    normal: '일반',
+    graduate: '졸업생',
+  };
+  const fetchData = () => {
+    return fetch('memberInfo.json')
+      .then(res => res.json())
+      .then(data => data.memberInfo);
+  };
+  const authentication = async data => {
+    const result = await fetchData();
+    for (const member of result) {
+      if (data.ID === member.ID) {
+        setLoginUserID(data.ID);
+        setLoginUserNickname(member.nickname);
+        const grades = Object.keys(gradeName);
+        const grade = grades.find(key => key === member.grade);
+        setLoginUserGrade(gradeName[grade]);
+        return true;
+      }
+    }
+    if (loginUserID === '') {
+      return false;
+    }
+  };
+  return auth ? (
+    <LogoutUserModal
+      id={loginUserID}
+      nickname={loginUserNickname}
+      grade={loginUserGrade}
+      setAuth={setAuth}
+    />
   ) : (
-    <LoginUserModal loginRequest={changeLoginRequest} />
+    <LoginUserModal loginRequest={loginRequest} />
   );
 }

--- a/frontend/src/components/UserModal.js
+++ b/frontend/src/components/UserModal.js
@@ -1,8 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import LoginUserModal from './LoginUserModal';
 import LogoutUserModal from './LogoutUserModal';
 
 export default function UserModal() {
-  const isLogin = false;
-  return isLogin ? <LogoutUserModal /> : <LoginUserModal />;
+  const [loginRequest, setLoginRequest] = useState(false);
+  const changeLoginRequest = state => {
+    setLoginRequest(state);
+  };
+  return loginRequest ? (
+    <LogoutUserModal loginRequest={changeLoginRequest} />
+  ) : (
+    <LoginUserModal loginRequest={changeLoginRequest} />
+  );
 }


### PR DESCRIPTION
# 로그인 시스템 구현 및 로고 누를 때 메인 페이지 이동

## 주요 변경 내용
- 로그인 시스템을 구현했습니다.
- 로고 누를 때 메인페이지로 이동합니다.

## 참고 사항
- 더미데이터에서 회원정보를 불러옵니다.

## 남은 작업 내용
- 새로고침 누를 때도 회원정보가 유지되도록 리덕스 스토어를 변경할 예정입니다.

## 참고용 시연 사진
![image](https://user-images.githubusercontent.com/81083461/226530579-e5d48bd5-1d05-419f-8903-71d67c621ff4.png)
![image](https://user-images.githubusercontent.com/81083461/226530664-cf154213-69ac-4c0f-b003-8e5df098ba81.png)
![image](https://user-images.githubusercontent.com/81083461/226530725-fdd6124c-858c-4dc0-911d-004231775986.png)
![image](https://user-images.githubusercontent.com/81083461/226530779-6af20f90-69e9-40f7-b56e-e9b342716af8.png)
![image](https://user-images.githubusercontent.com/81083461/226530862-6697319b-9c47-4872-beed-c8b1985ca16c.png)
