### PR TITLE
관리페이지 페이지네이션 적용 및 리팩토링

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "react-router": "^6.8.1",
         "react-router-dom": "^6.8.1",
         "react-scripts": "5.0.1",
+        "react-use-pagination": "^2.0.1",
         "recoil": "^0.7.7",
         "styled-components": "^5.3.6",
         "styled-reset": "^4.4.5",
@@ -15058,6 +15059,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-use-pagination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-use-pagination/-/react-use-pagination-2.0.1.tgz",
+      "integrity": "sha512-bo7vI2oZ/+PJJozN7DLWPkewrULLoHb8a6WO3dGudJfEKnj8BVZVbJPkvn5jtydhJ5xi0t0W7xI06XlWUe8Jbw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-hook-form": "^7.43.1",
         "react-js-pagination": "^3.0.3",
         "react-kakao-maps-sdk": "^1.1.9",
+        "react-loader-spinner": "^5.3.4",
         "react-quill": "^2.0.0",
         "react-router": "^6.8.1",
         "react-router-dom": "^6.8.1",
@@ -14894,6 +14895,20 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/react-loader-spinner": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.3.4.tgz",
+      "integrity": "sha512-G2vw4ssX+RDZ/vfaeva06yfNqyFViv/u+tVZ3kFLy5TKNlNx2DbuwreBSpRtPespQA+VxinxUJsigwLwG9erOg==",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "styled-components": "^5.3.5",
+        "styled-tools": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-onclickoutside": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
@@ -16268,6 +16283,11 @@
       "peerDependencies": {
         "styled-components": ">=4.0.0 || >=5.0.0"
       }
+    },
+    "node_modules/styled-tools": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/styled-tools/-/styled-tools-1.7.2.tgz",
+      "integrity": "sha512-IjLxzM20RMwAsx8M1QoRlCG/Kmq8lKzCGyospjtSXt/BTIIcvgTonaxQAsKnBrsZNwhpHzO9ADx5te0h76ILVg=="
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-router": "^6.8.1",
     "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
+    "react-use-pagination": "^2.0.1",
     "recoil": "^0.7.7",
     "styled-components": "^5.3.6",
     "styled-reset": "^4.4.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-hook-form": "^7.43.1",
     "react-js-pagination": "^3.0.3",
     "react-kakao-maps-sdk": "^1.1.9",
+    "react-loader-spinner": "^5.3.4",
     "react-quill": "^2.0.0",
     "react-router": "^6.8.1",
     "react-router-dom": "^6.8.1",

--- a/frontend/src/components/datePicker/datePicker.js
+++ b/frontend/src/components/datePicker/datePicker.js
@@ -108,16 +108,18 @@ function MyContainer({ className, children }) {
   // 날짜 선택 창 상단에 보이는 부분
   // 선택한 년월일을 확인할 수 있음
   return (
-    <DatePickerContainer className={className}>
-      <DatePickerTop>
-        <ShowYear>{`${selectedDate.getFullYear()}년`}</ShowYear>
-        <ShowDate>{`${
-          selectedDate.getMonth() + 1
-        }월 ${selectedDate.getDate()}일 ${
-          week[selectedDate.getDay()]
-        }요일`}</ShowDate>
-      </DatePickerTop>
-      <DatePickerBody>{children}</DatePickerBody>
+    <DatePickerContainer>
+      <DatePickerInner className={className}>
+        <DatePickerTop>
+          <ShowYear>{`${selectedDate.getFullYear()}년`}</ShowYear>
+          <ShowDate>{`${
+            selectedDate.getMonth() + 1
+          }월 ${selectedDate.getDate()}일 ${
+            week[selectedDate.getDay()]
+          }요일`}</ShowDate>
+        </DatePickerTop>
+        <DatePickerBody>{children}</DatePickerBody>
+      </DatePickerInner>
     </DatePickerContainer>
   );
 }
@@ -182,9 +184,20 @@ const DatePickerBody = styled.div`
   position: relative;
 `;
 
-const DatePickerContainer = styled(CalendarContainer)`
-  position: fixed;
-  top: 10%;
+const DatePickerInner = styled(CalendarContainer)`
+  position: absolute;
+  top: 0;
   left: 50%;
+  z-index: 1000;
   transform: translateX(-50%);
+`;
+
+const DatePickerContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
 `;

--- a/frontend/src/components/header/Navigation.js
+++ b/frontend/src/components/header/Navigation.js
@@ -9,17 +9,17 @@ export default function Navigation(props) {
     <NavigationContainer>
       <AncestorMenu>
         {props.ancestorMenuTree.map((menu, idx) => (
-          <>
+          <React.Fragment key={`menuTree${idx}`}>
             <AncestorMenuLink to={menu.link} key={`ancestor${idx}`}>
               {menu.name}
             </AncestorMenuLink>
             <RightAngleBracket key={`bracket${idx}`}>{' > '}</RightAngleBracket>
-          </>
+          </React.Fragment>
         ))}
       </AncestorMenu>
       <CurrentMenuTab>
         {props.currentTabContents.map((menu, idx) => (
-          <>
+          <React.Fragment key={`currentTab${idx}`}>
             <CurrentMenuTabContents
               to={menu.link}
               key={`current${idx}`}
@@ -30,7 +30,7 @@ export default function Navigation(props) {
             <VeticalBar key={`veticalBar${idx}`}>
               {idx < props.currentTabContents.length - 1 ? ` | ` : ''}
             </VeticalBar>
-          </>
+          </React.Fragment>
         ))}
       </CurrentMenuTab>
     </NavigationContainer>

--- a/frontend/src/components/manage/CabinetRentWindow.js
+++ b/frontend/src/components/manage/CabinetRentWindow.js
@@ -5,9 +5,9 @@ import styled from 'styled-components';
 import theme from '../../styles/Theme';
 import Button from '../util/Button';
 import EachCabinetManage from '../eachItem/EachCabinetManage';
-import { request } from '../../utils/axios';
 import ApproveModal from '../popup/ApproveModal';
 import useConfirm from '../../hook/useConfirm';
+import useFetch from '../../hook/useFetch';
 
 // 사물함 관리 페이지를 담당
 function CabinetRentWindow(props) {
@@ -17,28 +17,19 @@ function CabinetRentWindow(props) {
 
   const resetCabinet = useResetRecoilState(cabinet); // 사물함 상태 초기화
 
-  const fetchData = async () => {
-    try {
-      const response = await request('get', '/locker');
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/locker');
 
   // setInit에 서버의 상태 저장, 모달 창에 대한 상태는 다른 곳에 저장
   useEffect(() => {
-    const loadCabinetStatus = async () => {
-      const result = await fetchData();
-      setInit(result);
+    if (data) {
+      setInit(data);
       setCabinetList(init);
-    };
-    loadCabinetStatus();
+    }
 
     return () => {
       resetCabinet();
     };
-  }, []);
+  }, [data]);
 
   const confirmGrant = () => {
     console.log('반영 성공');

--- a/frontend/src/components/manage/MemberAuthorizeWindow.js
+++ b/frontend/src/components/manage/MemberAuthorizeWindow.js
@@ -9,6 +9,7 @@ import { request } from '../../utils/axios';
 import useConfirm from '../../hook/useConfirm';
 import ConfirmMessage from '../../constants/ConfirmMessage';
 import useFetch from '../../hook/useFetch';
+import Loading from './../util/Loading';
 
 // 회원 승인 화면을 담당
 function MemberAuthorizeWindow(props) {
@@ -122,7 +123,10 @@ function MemberAuthorizeWindow(props) {
           </tr>
         </WaitingMemberHeader>
         <WaitingMemberList>
-          {waitingMember &&
+          {loading ? (
+            <Loading />
+          ) : (
+            waitingMember &&
             checkboxList.length > 0 &&
             waitingMember.map((member, index) => (
               <EachWaitingMember
@@ -136,7 +140,8 @@ function MemberAuthorizeWindow(props) {
                 isChecked={checkboxList[index].isChecked}
                 onChange={checkHandler}
               />
-            ))}
+            ))
+          )}
         </WaitingMemberList>
       </WaitingMemberContainer>
       <ActionButtonContainer>

--- a/frontend/src/components/manage/MemberAuthorizeWindow.js
+++ b/frontend/src/components/manage/MemberAuthorizeWindow.js
@@ -8,6 +8,7 @@ import useCheckbox from '../../hook/useCheckbox';
 import { request } from '../../utils/axios';
 import useConfirm from '../../hook/useConfirm';
 import ConfirmMessage from '../../constants/ConfirmMessage';
+import useFetch from '../../hook/useFetch';
 
 // 회원 승인 화면을 담당
 function MemberAuthorizeWindow(props) {
@@ -22,34 +23,22 @@ function MemberAuthorizeWindow(props) {
     checkHandler,
   } = useCheckbox([]);
 
-  const fetchData = async () => {
-    try {
-      const response = await request('post', '/admin/applicant', {
-        id: 'C011001',
-      });
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/admin/applicant');
 
   useEffect(() => {
-    const loadWaitingMember = async () => {
-      const result = await fetchData();
-      setWaitingMember(result);
+    if (data) {
+      setWaitingMember(data);
 
       // checkbox 초기 상태 설정
-      if (result.length > 0) {
-        const initialList = result.map(member => ({
+      if (data.length > 0) {
+        const initialList = data.map(member => ({
           id: member.id,
           isChecked: false,
         }));
         setCheckboxList(initialList);
       }
-    };
-
-    loadWaitingMember();
-  }, []);
+    }
+  }, [data]);
 
   // 승인 거절을 눌렀을 때 실행되는 함수
   // 이 파트는 실제 백엔드와 협의하여 제작함

--- a/frontend/src/components/manage/MemberDetail.js
+++ b/frontend/src/components/manage/MemberDetail.js
@@ -13,6 +13,7 @@ import { memberRole } from '../../constants/MemberRole';
 import { request } from '../../utils/axios';
 import getKeyByValue from '../../utils/getKeyByValue';
 import useSelect from '../../hook/useSelect';
+import useFetch from '../../hook/useFetch';
 
 // 회원 상세 페이지를 담당
 export default function MemberDetail() {
@@ -22,22 +23,14 @@ export default function MemberDetail() {
   const [selectedRole, setSelectedRole] = useSelect(memberRole.GENERAL); // 회원 등급 선택
   const navigate = useNavigate();
 
+  const { data, loading, error } = useFetch(`/admin/member/detail/${user}`);
+
   // 회원정보 로드
   useEffect(() => {
-    const loadUserInfo = async () => {
-      const body = {
-        id: 'C011001',
-        nickname: user,
-      };
-      try {
-        const response = await request('post', `/admin/member/detail`, body);
-        setUserinfo(response);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    loadUserInfo();
-  }, [user]);
+    if (data) {
+      setUserinfo(data);
+    }
+  }, [user, data]);
 
   // 회원 정보를 저장할 때 실행되는 함수
   // 이 파트는 실제 백엔드와 협의하여 제작함

--- a/frontend/src/components/manage/MemberInfoWindow.js
+++ b/frontend/src/components/manage/MemberInfoWindow.js
@@ -15,6 +15,7 @@ import useCheckbox from '../../hook/useCheckbox';
 import { filterOptionValue } from '../../constants/FilterOptionValue';
 import Filter from '../util/Filter';
 import Button from '../util/Button';
+import useFetch from '../../hook/useFetch';
 
 // 회원 목록을 담당
 function MemberInfoWindow(props) {
@@ -32,36 +33,23 @@ function MemberInfoWindow(props) {
     checkHandler,
   } = useCheckbox([]);
 
-  // 멤버 정보 더미데이터 불러옵니다.
-  const fetchData = async () => {
-    try {
-      const response = await request('post', '/admin/member', {
-        id: 'C011001',
-      });
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/admin/member');
 
   // 정보 로드
   useEffect(() => {
-    const loadMemberInfo = async () => {
-      const result = await fetchData(); // array 내부는 Object
-      setMemberInfo(result);
+    if (data) {
+      setMemberInfo(data);
 
       // checkbox 초기 상태 설정
-      if (result.length > 0) {
-        const initialList = result.map(member => ({
+      if (data.length > 0) {
+        const initialList = data.map(member => ({
           id: member.id,
           isChecked: false,
         }));
         setCheckboxList(initialList);
       }
-    };
-
-    loadMemberInfo();
-  }, []);
+    }
+  }, [data]);
 
   useEffect(() => {
     console.log(checkboxList);

--- a/frontend/src/components/manage/MemberInfoWindow.js
+++ b/frontend/src/components/manage/MemberInfoWindow.js
@@ -16,13 +16,27 @@ import { filterOptionValue } from '../../constants/FilterOptionValue';
 import Filter from '../util/Filter';
 import Button from '../util/Button';
 import useFetch from '../../hook/useFetch';
+import useInput from '../../hook/useInput';
+
+import { usePagination } from 'react-use-pagination';
+import Paging from '../paging/Paging';
 
 // 회원 목록을 담당
 function MemberInfoWindow(props) {
   const [memberInfo, setMemberInfo] = useState([]); // 회원 정보를 담고 있다.
+  const [curPageMember, setCurPageMember] = useState([]); // 현재 페이지 멤버
+  const pageSize = 10; // 페이지 사이즈
+
   const [selectedRole, setSelectedRole] = useSelect(memberRole.GENERAL); // 회원 등급을 조정
   const [sort, setSort] = useSelect(filterOptionValue.member.role); // 정렬 기준을 조정
-  const [keyword, setkeyword] = useState(''); // 검색창
+  const [keyword, setkeyword] = useInput(''); // 검색창
+
+  // pagination
+  const { currentPage, startIndex, endIndex, setPage } = usePagination({
+    totalItems: memberInfo.length,
+    initialPageSize: pageSize,
+    initialPage: 0,
+  });
 
   // 체크 박스를 위해
   const {
@@ -39,10 +53,11 @@ function MemberInfoWindow(props) {
   useEffect(() => {
     if (data) {
       setMemberInfo(data);
+      setCurPageMember(data.slice(0, pageSize));
 
       // checkbox 초기 상태 설정
       if (data.length > 0) {
-        const initialList = data.map(member => ({
+        const initialList = data.slice(0, pageSize).map(member => ({
           id: member.id,
           isChecked: false,
         }));
@@ -51,9 +66,19 @@ function MemberInfoWindow(props) {
     }
   }, [data]);
 
+  // 페이지가 변동될 때마다 새로 체크박스 관리를 해주어야하기 때문
+  // 두 라이브러리 호환문제로 인해 endIndex + 1 처리
   useEffect(() => {
-    console.log(checkboxList);
-  }, [checkboxList]);
+    const currentPageMember = memberInfo.slice(startIndex, endIndex + 1);
+    setCurPageMember(currentPageMember);
+
+    const checkboxList = currentPageMember.map(member => ({
+      id: member.id,
+      isChecked: false,
+    }));
+
+    setCheckboxList(checkboxList);
+  }, [currentPage]);
 
   // 변경정보를 받아와 멤버정보를 수정합니다.
   // 백엔드 개발자와 협의 완료
@@ -93,31 +118,37 @@ function MemberInfoWindow(props) {
 
     if (sortBy === '이름 순') {
       const sortedMember = [...memberInfo].sort(sortByName);
+      const currentPageMember = sortedMember.slice(0, pageSize);
       const sortedChecklist = sortedMember.map(member => ({
         id: member.id,
         isChecked: false,
       }));
       setMemberInfo(sortedMember);
+      setCurPageMember(currentPageMember);
       setCheckboxList(sortedChecklist);
     }
 
     if (sortBy === '학번 순') {
       const sortedMember = [...memberInfo].sort(sortById);
+      const currentPageMember = sortedMember.slice(0, pageSize);
       const sortedChecklist = sortedMember.map(member => ({
         id: member.id,
         isChecked: false,
       }));
       setMemberInfo(sortedMember);
+      setCurPageMember(currentPageMember);
       setCheckboxList(sortedChecklist);
     }
 
     if (sortBy === '등급 순') {
       const sortedMember = [...memberInfo].sort(sortByRole);
+      const currentPageMember = sortedMember.slice(0, pageSize);
       const sortedChecklist = sortedMember.map(member => ({
         id: member.id,
         isChecked: false,
       }));
       setMemberInfo(sortedMember);
+      setCurPageMember(currentPageMember);
       setCheckboxList(sortedChecklist);
     }
   };
@@ -139,9 +170,34 @@ function MemberInfoWindow(props) {
   };
 
   // 검색 결과를 보여주는 함수
-  // 아직 미구현
   const searchMember = () => {
-    console.log(keyword);
+    if (keyword.trim() === '') return;
+
+    // 닉네임, 이름, 학번, 전화번호, 전공 검색
+    // 어 등급은 그냥 정렬로 확인하세요...ㅋㅋㅋㅋㅋㅋ
+    const searchResult = memberInfo.filter(
+      member =>
+        member.nickname.toLowerCase().includes(keyword.toLowerCase()) ||
+        member.name.includes(keyword) ||
+        member.id.toLowerCase().includes(keyword.toLowerCase()) ||
+        member.phoneNumber.includes(keyword) ||
+        member.major.includes(keyword),
+    );
+
+    const currentPageMember = searchResult.slice(0, pageSize);
+    const newChecklist = searchResult.map(member => ({
+      id: member.id,
+      isChecked: false,
+    }));
+
+    setMemberInfo(searchResult);
+    setCurPageMember(currentPageMember);
+    setCheckboxList(newChecklist);
+  };
+
+  // 두 라이브러리 호환문제로 page-1 처리
+  const setPages = page => {
+    setPage(page - 1);
   };
 
   return (
@@ -171,7 +227,8 @@ function MemberInfoWindow(props) {
         <MemberList>
           {memberInfo &&
             checkboxList.length > 0 &&
-            memberInfo.map((value, index) => {
+            curPageMember &&
+            curPageMember.map((value, index) => {
               return (
                 <EachRegisteredMember
                   key={value.id}
@@ -189,13 +246,20 @@ function MemberInfoWindow(props) {
         </MemberList>
       </MemberContainer>
 
+      <Paging
+        page={currentPage + 1}
+        pageSize={pageSize}
+        count={memberInfo.length}
+        setPage={setPages}
+      />
+
       <FilterContainer>
         <Filter optionValue={filterOptionValue.member} onChange={sortMember} />
         <Gap />
         <KeywordSearch
           placeholder="검색어를 입력하세요"
           value={keyword}
-          onChange={event => setkeyword(event.target.value)}
+          onChange={setkeyword}
         />
         <SearchButton buttonName="검색" onClick={searchMember} />
       </FilterContainer>

--- a/frontend/src/components/manage/UmbrellaRentWindow.js
+++ b/frontend/src/components/manage/UmbrellaRentWindow.js
@@ -5,34 +5,25 @@ import { useRecoilState, useResetRecoilState } from 'recoil';
 import { umbrella } from '../../atom/umbrella';
 import EachUmbrellaManage from '../eachItem/EachUmbrellaManage';
 import Button from '../util/Button';
-import { request } from '../../utils/axios';
 import useConfirm from '../../hook/useConfirm';
+import useFetch from '../../hook/useFetch';
 
 // 우산 관리 페이지를 담당
 function UmbrellaRentWindow(props) {
   const [umbrellaList, setUmbrellaList] = useRecoilState(umbrella); // 우산 리스트
   const resetUmbrella = useResetRecoilState(umbrella); // 우산 상태 초기화
 
-  const fetchData = async () => {
-    try {
-      const response = await request('get', '/umbrella');
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/umbrella');
 
   useEffect(() => {
-    const loadUmbrellaStatus = async () => {
-      const result = await fetchData();
-      setUmbrellaList(result);
-    };
-    loadUmbrellaStatus();
+    if (data) {
+      setUmbrellaList(data);
+    }
 
     return () => {
       resetUmbrella();
     };
-  }, []);
+  }, [data]);
 
   // 우산 상태를 저장하는 기능
   // 아직 백엔드 통신 코드는 작성하지 않음

--- a/frontend/src/components/noticeboard/Post.js
+++ b/frontend/src/components/noticeboard/Post.js
@@ -142,6 +142,7 @@ export default function Post(props) {
           </Pagination> */}
           <Paging
             page={currentPage}
+            pageSize={postsPerPage}
             count={filteredPostsCount}
             setPage={setPage}
           />

--- a/frontend/src/components/noticeboard/Restaurant.js
+++ b/frontend/src/components/noticeboard/Restaurant.js
@@ -3,9 +3,9 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import styled from 'styled-components';
 import theme from '../../styles/Theme';
 import Button from '../util/Button';
-import { request } from '../../utils/axios';
 import EachReviewCard from '../eachItem/EachReviewCard';
 import useScrollGradient from '../../hook/useScrollGradient';
+import useFetch from '../../hook/useFetch';
 
 // 일단은 별도의 페이지로 제작한 후 나중에 협의하에 게시판 안으로 밀어넣어보자
 function Restaurant(props) {
@@ -18,23 +18,13 @@ function Restaurant(props) {
 
   const kakao = window.kakao;
 
-  const fetchData = async () => {
-    try {
-      const response = await request('get', '/noticeboard/restaurant');
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/noticeboard/restaurant');
 
   useEffect(() => {
-    const loadRestaurantList = async () => {
-      const result = await fetchData();
-      setRestaurantList(result);
-    };
-
-    loadRestaurantList();
-  }, []);
+    if (data) {
+      setRestaurantList(data);
+    }
+  }, [data]);
 
   const markerClick = placeid => {
     const currentRestaurant = restaurantList.filter(

--- a/frontend/src/components/paging/Paging.js
+++ b/frontend/src/components/paging/Paging.js
@@ -2,12 +2,12 @@ import React from 'react';
 import Pagination from 'react-js-pagination';
 import '../../styles/paging.css';
 
-export default function Paging({ page, count, setPage }) {
+export default function Paging({ page, pageSize, count, setPage }) {
   return (
     <>
       <Pagination
         activePage={page}
-        itemsCountPerPage={10}
+        itemsCountPerPage={pageSize}
         totalItemsCount={count}
         pageRangeDisplayed={5}
         prevPageText={'<'}

--- a/frontend/src/components/popup/ScheduleModal.js
+++ b/frontend/src/components/popup/ScheduleModal.js
@@ -55,8 +55,8 @@ export default function ScheduleModal(props) {
       </ScheduleModalHeader>
       <ScheduleInputContainer onSubmit={onSubmit}>
         <InputRow>
-          <InputRowLable>제목</InputRowLable>
-          <Input required />
+          <InputRowLable>일정 제목</InputRowLable>
+          <Input required height={30} />
         </InputRow>
         <InputRow>
           <InputRowLable>날짜</InputRowLable>
@@ -65,22 +65,15 @@ export default function ScheduleModal(props) {
             value={moment(selectDate).format('yyyy-MM-DD')}
             disabled
             required
+            height={30}
           />
           <DatePickerContainer>
             <CustomDatePicker />
           </DatePickerContainer>
         </InputRow>
         <InputRow>
-          <InputRowLable>시간</InputRowLable>
-          <Input type="time" />
-        </InputRow>
-        <InputRow>
-          <InputRowLable>장소</InputRowLable>
-          <Input required />
-        </InputRow>
-        <InputRow>
           <InputRowLable>세부사항</InputRowLable>
-          <Input required />
+          <Input required height={78} />
         </InputRow>
         <ButtonContainer>
           <CancleButton buttonName="취소" onClick={props.onClose} />
@@ -150,6 +143,7 @@ const ScheduleInputContainer = styled.form`
 
 const InputRow = styled.div`
   position: relative;
+  width: 580px;
   margin-bottom: 10px;
 `;
 
@@ -159,11 +153,12 @@ const InputRowLable = styled.div`
   font-family: 'Pretendard';
   font-size: 20px;
   font-weight: 300;
+  text-align: left;
 `;
 
 const Input = styled.input`
   width: 580px;
-  height: 40px;
+  height: ${props => `${props.height}px`};
   background-color: transparent;
   border: none;
   border-bottom: 1px solid rgba(237, 240, 248, 0.7);

--- a/frontend/src/components/util/Loading.js
+++ b/frontend/src/components/util/Loading.js
@@ -1,0 +1,28 @@
+import { Oval } from 'react-loader-spinner';
+import styled from 'styled-components';
+
+function Loading() {
+  return (
+    <OvalContainer>
+      <Oval
+        height={80}
+        width={80}
+        color="#4fa94d"
+        wrapperStyle={{}}
+        wrapperClass=""
+        visible={true}
+        ariaLabel="oval-loading"
+        secondaryColor="#4fa94d"
+        strokeWidth={2}
+        strokeWidthSecondary={2}
+      />
+    </OvalContainer>
+  );
+}
+
+export default Loading;
+
+const OvalContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;

--- a/frontend/src/constants/Caution.js
+++ b/frontend/src/constants/Caution.js
@@ -16,8 +16,8 @@ export default function Caution({ item }) {
         <CautionTitle>대여 시 주의사항</CautionTitle>
       </CautionHeader>
       <CautionContent>
-        {match[item].map(message => (
-          <CautionLine>{message}</CautionLine>
+        {match[item].map((message, idx) => (
+          <CautionLine key={`${item}-${idx}`}>{message}</CautionLine>
         ))}
       </CautionContent>
     </CautionContainer>

--- a/frontend/src/hook/useFetch.js
+++ b/frontend/src/hook/useFetch.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { request } from './../utils/axios';
+
+// useFetch
+// 서버로부터 get으로 정보를 받아올 때 사용
+// parameter: url: base_url 제외한 뒷 부분
+// return: data: 서버에서 받은 값, loading: 로딩 중, error: 에러
+function useFetch(url) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchData = async () => {
+    try {
+      const response = await request('get', url);
+      setData(response);
+    } catch (error) {
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  return { data, loading, error };
+}
+
+export default useFetch;

--- a/frontend/src/hook/useInput.js
+++ b/frontend/src/hook/useInput.js
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react';
+
+function useInput(initialValue) {
+  const [value, setValue] = useState(initialValue);
+
+  const onChange = useCallback(event => {
+    setValue(event.target.value);
+  }, []);
+
+  return [value, onChange];
+}
+
+export default useInput;

--- a/frontend/src/mocks/data/memberInfo.json
+++ b/frontend/src/mocks/data/memberInfo.json
@@ -1,10 +1,122 @@
 [
-  {"nickname": "ezwoo", "name": "이지우", "id": "C211000", "phoneNumber": "010-1234-5678", "role": "PRESIDENT", "major": "컴퓨터공학과"},
-  {"nickname": "banana", "name": "경수현", "id": "C031000", "phoneNumber": "010-1234-5678", "role": "EXECUTIVE", "major": "경영학과"},
-  {"nickname": "pineapple", "name": "김진호", "id": "B731000", "phoneNumber": "010-1234-5678", "role": "EXECUTIVE", "major": "경영학과"},
-  {"nickname": "melon", "name": "김효진", "id": "C119000", "phoneNumber": "010-1234-5678", "role": "EXECUTIVE", "major": "신소재화공"},
-  {"nickname": "strawberry", "name": "김화윤", "id": "C219001", "phoneNumber": "010-1234-5678", "role": "GENERAL", "major": "신소재화공"},
-  {"nickname": "orange", "name": "장민지", "id": "C211003", "phoneNumber": "010-1234-5678", "role": "GENERAL", "major": "컴퓨터공학과"},
-  {"nickname": "pear", "name": "윤찬호", "id": "B915000", "phoneNumber": "010-1234-5678", "role": "GENERAL", "major": "컴퓨터공학과"},
-  {"nickname": "peach", "name": "김준호", "id": "C015000", "phoneNumber": "010-1234-5678", "role": "GRADUATE", "major": "전자전기공학과"}
+  {
+    "nickname": "ezwoo",
+    "name": "이지우",
+    "id": "C211000",
+    "phoneNumber":"010-1234-5678",
+    "role": "PRESIDENT",
+    "major": "컴퓨터공학과"
+  },
+  {
+    "nickname": "banana",
+    "name": "경수현",
+    "id": "C031000",
+    "phoneNumber": "010-1234-5678",
+    "role": "EXECUTIVE",
+    "major": "경영학과"
+  },
+  {
+    "nickname": "pineapple",
+    "name": "김진호",
+    "id": "B731000",
+    "phoneNumber": "010-1234-5678",
+    "role": "EXECUTIVE",
+    "major": "경영학과"
+  },
+  {
+    "nickname": "melon",
+    "name": "김효진",
+    "id": "C119000",
+    "phoneNumber": "010-1234-5678",
+    "role": "EXECUTIVE",
+    "major": "신소재화공"
+  },
+  {
+    "nickname": "strawberry",
+    "name": "김화윤",
+    "id": "C219001",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "신소재화공"
+  },
+  {
+    "nickname": "orange",
+    "name": "장민지",
+    "id": "C211003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "컴퓨터공학과"
+  },
+  {
+    "nickname": "pear",
+    "name": "윤찬호",
+    "id": "B915000",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "컴퓨터공학과"
+  },
+  {
+    "nickname": "peach",
+    "name": "김준호",
+    "id": "C015000",
+    "phoneNumber": "010-1234-5678",
+    "role": "GRADUATE",
+    "major": "전자전기공학과"
+  },
+  {
+    "nickname": "sseho",
+    "name": "최세호",
+    "id": "B811003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "컴퓨터공학과"
+  },
+  {
+    "nickname": "binaryho",
+    "name": "이진호",
+    "id": "B715003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "전자전기공학과"
+  },
+  {
+    "nickname": "yoonseo",
+    "name": "이윤서",
+    "id": "C046003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "시각디자인학과"
+  },
+  {
+    "nickname": "nayeong",
+    "name": "구나영",
+    "id": "C148003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "판화과"
+  },
+  {
+    "nickname": "shjhi",
+    "name": "송현지",
+    "id": "C135003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "자율전공학과"
+  },
+  {
+    "nickname": "anseongmin",
+    "name": "안성민",
+    "id": "C215003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "전자전기공학과"
+  },
+  {
+    "nickname": "seoyeong",
+    "name": "최서영",
+    "id": "C235003",
+    "phoneNumber": "010-1234-5678",
+    "role": "GENERAL",
+    "major": "자율전공학과"
+  }
 ]

--- a/frontend/src/mocks/data/watingMember.json
+++ b/frontend/src/mocks/data/watingMember.json
@@ -78,5 +78,14 @@
     "phoneNumber": "010-9999-9999",
     "role": "GUEST",
     "major": "컴퓨터공학과"
-  }
+  },
+  {"name": "이지우원", "id": "C211001", "nickname": "ezwoo", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "컴퓨터공학과"},
+  {"nickname": "banana", "name": "이지우투", "id": "C031001", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "경영학과"},
+  {"nickname": "pineapple", "name": "이지우쓰리", "id": "B731001", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "경영학과"},
+  {"nickname": "melon", "name": "이지우포", "id": "C119001", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "신소재화공"},
+  {"nickname": "strawberry", "name": "이지우파이브", "id": "C219002", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "신소재화공"},
+  {"nickname": "orange", "name": "이지우식스", "id": "C211004", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "컴퓨터공학과"},
+  {"nickname": "pear", "name": "이지우세븐", "id": "B915010", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "컴퓨터공학과"},
+  {"nickname": "peach", "name": "이지우에잇", "id": "C015001", "phoneNumber": "010-1234-5678", "role": "GUEST", "major": "전자전기공학과"}
+
 ]

--- a/frontend/src/mocks/handlers/manage.js
+++ b/frontend/src/mocks/handlers/manage.js
@@ -7,6 +7,10 @@ export const manageHandlers = [
   // 승인 대기자 조회
   rest.get(`${BASE_URL}/admin/applicant`, async (req, res, ctx) => {
     const response = applicant;
+
+    // 2초 후에 응답 보내기
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     return res(ctx.json(response));
   }),
 

--- a/frontend/src/mocks/handlers/manage.js
+++ b/frontend/src/mocks/handlers/manage.js
@@ -5,29 +5,26 @@ import applicant from '../data/watingMember.json';
 
 export const manageHandlers = [
   // 승인 대기자 조회
-  rest.post(`${BASE_URL}/admin/applicant`, async (req, res, ctx) => {
+  rest.get(`${BASE_URL}/admin/applicant`, async (req, res, ctx) => {
     const response = applicant;
     return res(ctx.json(response));
   }),
 
   // 모든 회원정보 조회
-  rest.post(`${BASE_URL}/admin/member`, async (req, res, ctx) => {
+  rest.get(`${BASE_URL}/admin/member`, async (req, res, ctx) => {
     const response = allMember;
     return res(ctx.json(response));
   }),
 
   // 회원 상세정보 조회
-  rest.post(`${BASE_URL}/admin/member/detail`, async (req, res, ctx) => {
-    const response = {
-      id: 'C011001',
-      role: 'PRESIDENT',
-      phoneNumber: '010-2134-2134',
-      nickname: 'ezwoo',
-      name: '이지우',
-      major: 'computer',
-    };
-    return res(ctx.json(response));
-  }),
+  rest.get(
+    `${BASE_URL}/admin/member/detail/:nickname`,
+    async (req, res, ctx) => {
+      const { nickname } = req.params;
+      const response = allMember.find(member => member.nickname === nickname);
+      return res(ctx.json(response));
+    },
+  ),
 
   // 회원 강퇴
   rest.post(`${BASE_URL}/admin/expel`, async (req, res, ctx) => {

--- a/frontend/src/pages/CabinetRent.js
+++ b/frontend/src/pages/CabinetRent.js
@@ -13,6 +13,7 @@ import { cabinet, cabinetModal, currentCabinetIndex } from '../atom/cabinet';
 import Header from '../components/header/Header';
 import Navigation from '../components/header/Navigation';
 import { request } from '../utils/axios';
+import useFetch from '../hook/useFetch';
 
 // 사물함 대여 페이지
 export default function CabinetRent(props) {
@@ -26,29 +27,19 @@ export default function CabinetRent(props) {
 
   const checkMyRent = useMyRent(); // 내가 대여 처리
 
-  const fetchData = async () => {
-    try {
-      const response = await request('get', '/locker');
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/locker');
 
   useEffect(() => {
-    const loadCabinetStatus = async () => {
-      const result = await fetchData();
-      const cabinetListIncludeMyRent = checkMyRent(result, myName);
+    if (data) {
+      const cabinetListIncludeMyRent = checkMyRent(data, myName);
       setInit(cabinetListIncludeMyRent);
       setCabinetList(init);
-    };
-
-    loadCabinetStatus();
+    }
 
     return () => {
       resetCabinet();
     };
-  }, []);
+  }, [data]);
 
   const modalRef = useRef(null);
 
@@ -58,8 +49,8 @@ export default function CabinetRent(props) {
     { name: '대여', link: '/rent/umbrellarent' },
   ];
   const currentTabContents = [
-    { name: '우산 대여', link: '/rent/umbrellarent', accent: false },
-    { name: '사물함 대여', link: '/rent/cabinetrent', accent: true },
+    { name: '우산 대여', link: '/rent/umbrellarent', accent: 0 },
+    { name: '사물함 대여', link: '/rent/cabinetrent', accent: 1 },
   ];
 
   return (

--- a/frontend/src/pages/Calendar.js
+++ b/frontend/src/pages/Calendar.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import moment from 'moment';
 import data from '../data/data.json';
@@ -6,6 +6,7 @@ import theme from '../styles/Theme';
 import ScheduleModal from '../components/popup/ScheduleModal';
 import Title from '../components/header/Title';
 import Header from '../components/header/Header';
+import useModal from '../hook/useModal';
 
 function CalendarBox(props) {
   const plans = [];
@@ -55,28 +56,12 @@ function Calendar() {
   const [date, setDate] = useState(moment());
 
   const modalRef = useRef(null);
-  const [modalOpen, setModalOpen] = useState(false);
-
-  useEffect(() => {
-    const handleClickOutside = event => {
-      if (
-        modalRef.current == null ||
-        !modalRef.current.contains(event.target)
-      ) {
-        setModalOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [modalRef]);
+  const modalOpen = useModal(modalRef);
 
   const daysInMonth = date.daysInMonth(); //달의 마지막날
   const firstDayOfMonth = moment(date).startOf('month').format('d'); //달의 시작날 수
 
   const dayArray = ['일', '월', '화', '수', '목', '금', '토']; //요일
-
   const days = [];
 
   for (let i = 0; i < firstDayOfMonth; i++) {
@@ -86,7 +71,6 @@ function Calendar() {
   for (let d = 1; d <= daysInMonth; d++) {
     days.push(d);
   }
-  console.log(days);
 
   const goToPrevMonth = () => {
     setDate(moment(date).subtract(1, 'month'));
@@ -107,9 +91,10 @@ function Calendar() {
           {date.year()}년 {date.month() + 1}월
           <CalendarButton onClick={goToNextMonth}>{'>'}</CalendarButton>
         </CalendarTopContent>
-        <AddScheduleButton
-          onClick={() => setModalOpen(!modalOpen)}
-        >{`일정추가 +`}</AddScheduleButton>
+        <AddScheduleModal ref={modalRef}>
+          {`일정추가 +`}
+          {modalOpen && <ScheduleModal />}
+        </AddScheduleModal>
       </CalendarTop>
       <CalendarMain>
         {dayArray.map((day, idx) => (
@@ -119,9 +104,6 @@ function Calendar() {
           <CalendarBox date={day} isSunday={idx % 7 === 0}></CalendarBox>
         ))}
       </CalendarMain>
-      <div ref={modalRef}>
-        {modalOpen && <ScheduleModal onClose={() => setModalOpen(false)} />}
-      </div>
     </MainContainer>
   );
 }
@@ -175,9 +157,7 @@ const CalendarTopContent = styled.div`
   transform: translate(-50%, 0);
 `;
 
-const AddScheduleButton = styled.button`
-  background-color: transparent;
-  border: none;
+const AddScheduleModal = styled.div`
   color: ${theme.colors.white};
 
   font-family: 'Pretendard';

--- a/frontend/src/pages/UmbrellaRent.js
+++ b/frontend/src/pages/UmbrellaRent.js
@@ -16,7 +16,7 @@ import ApplyModal from '../components/popup/ApplyModal';
 import moment from 'moment';
 import Header from '../components/header/Header';
 import Navigation from '../components/header/Navigation';
-import { request } from '../utils/axios';
+import useFetch from '../hook/useFetch';
 
 /*
 currentTabContents는 현재 탭의 정보로
@@ -34,29 +34,19 @@ export default function UmbrellaRent(props) {
 
   const checkMyRent = useMyRent(); // 내가 대여 처리
 
-  const fetchData = async () => {
-    try {
-      const response = await request('get', '/umbrella');
-      return response;
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { data, loading, error } = useFetch('/umbrella');
 
   useEffect(() => {
-    const loadUmbrellaStatus = async () => {
-      const result = await fetchData();
-      const umbrellaListIncludeMyRent = checkMyRent(result, myName);
+    if (data) {
+      const umbrellaListIncludeMyRent = checkMyRent(data, myName);
       setInit(umbrellaListIncludeMyRent);
       setUmbrellaList(init);
-    };
-
-    loadUmbrellaStatus();
+    }
 
     return () => {
       resetUmbrella();
     };
-  }, []);
+  }, [data]);
 
   const now = new Date(); //  오늘 날짜
   const sevenDaysAgo = new Date(now.setDate(now.getDate() + 7)); // 우산 반납은 7일 후로 고정
@@ -69,8 +59,8 @@ export default function UmbrellaRent(props) {
     { name: '대여', link: '/rent/umbrellarent' },
   ];
   const currentTabContents = [
-    { name: '우산 대여', link: '/rent/umbrellarent', accent: true },
-    { name: '사물함 대여', link: '/rent/cabinetrent', accent: false },
+    { name: '우산 대여', link: '/rent/umbrellarent', accent: 1 },
+    { name: '사물함 대여', link: '/rent/cabinetrent', accent: 0 },
   ];
 
   return (


### PR DESCRIPTION
# 관리페이지 페이지네이션 적용 및 리팩토링

## 주요 변경 내용
- 관리페이지에 페이지네이션을 적용했습니다.
- useFetch 커스텀 훅을 만들어 서버에서 단순 가져오는 get 메서드는 useFetch에서 관리하도록 변경했습니다.
- useFetch에서 loading기능을 넣었으며, 로딩 화면을 보여주는 화면을 제작했습니다. 임의로
- 관리페이지에서 페이지네이션이 적용됐으며, 정렬과 검색을 지원합니다.

## 참고 사항
- 현재 페이지네이션 방식은 client-side-pagination 방식입니다.
- 회원 검색에서 등급은 제외했습니다. (등급은 어 그냥 정렬에서 하라고...ㅋㅋㅋㅋ)

## 남은 작업 내용
- 관리페이지는 작업이 끝난 것 같지만 추후에 고칠 것이 있다면 수정할 예정입니다.

## 참고용 시연 사진
<img width="960" alt="image" src="https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/57deb258-9db5-4a13-ac18-59c5895f687a">
<img width="960" alt="image" src="https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/b56468af-97ef-4622-b5c7-ccaf67f98cd7">
<img width="960" alt="image" src="https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/52646ee4-4133-4d74-a742-353855722ddf">
<img width="960" alt="image" src="https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/8d9f67bb-bafa-49fe-948d-a8d21bc0948a">
