### PR TITLE
Design: 페이지 레이아웃 파일 생성

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,29 +1,30 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Main from './pages/Main';
-import Signup from './pages/Signup';
-import Calendar from './pages/Calendar';
-import MyPage from './pages/MyPage';
-import Manage from './pages/Manage';
-import Noticeboard from './pages/Noticeboard';
-import MemberDetail from './components/manage/MemberDetail';
-import Login from './pages/Login';
-import CabinetRent from './pages/CabinetRent';
-import UmbrellaRent from './pages/UmbrellaRent';
+import { Route, Routes } from 'react-router-dom';
+import Layout from './components/layout/Layout';
 import { useRecoilValue } from 'recoil';
 import { user } from './atom/user';
+import Main from './pages/Main';
+import Login from './pages/Login';
+import Signup from './pages/Signup';
 import TOS from './pages/TOS';
-import PresidentRoute from './permissionRoute/PresidentRoute';
-import AdminRoute from './permissionRoute/AdminRoute';
+import Calendar from './pages/Calendar';
 import PrivateRoute from './permissionRoute/PrivateRoute';
+import Mypage from './pages/MyPage';
+import AdminRoute from './permissionRoute/AdminRoute';
+import Manage from './pages/Manage';
+import Noticeboard from './pages/Noticeboard';
+import PresidentRoute from './permissionRoute/PresidentRoute';
+import MemberDetail from './components/manage/MemberDetail';
 import UndergraduateRoute from './permissionRoute/UndergraduateRoute';
+import UmbrellaRent from './pages/UmbrellaRent';
+import CabinetRent from './pages/CabinetRent';
 
-function Router() {
+function App() {
   const isLogin = useRecoilValue(user).accessToken;
   const role = useRecoilValue(user).role;
   return (
-    <BrowserRouter>
-      <Routes>
+    <Routes>
+      <Route element={<Layout />}>
         <Route path="/" element={<Main />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
@@ -35,7 +36,7 @@ function Router() {
             <PrivateRoute
               authenticated={isLogin}
               permission={role}
-              component={<MyPage />}
+              component={<Mypage />}
             />
           }
         />
@@ -89,9 +90,9 @@ function Router() {
             />
           }
         />
-      </Routes>
-    </BrowserRouter>
+      </Route>
+    </Routes>
   );
 }
 
-export default Router;
+export default App;

--- a/frontend/src/atom/endSelect.js
+++ b/frontend/src/atom/endSelect.js
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+
+// datepicker에서 날짜를 선택할 때를 위해 쓰임
+export const endSelect = atom({
+  key: 'endSelect',
+  default: new Date(),
+});

--- a/frontend/src/components/datePicker/datePicker.js
+++ b/frontend/src/components/datePicker/datePicker.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DatePicker, { CalendarContainer } from 'react-datepicker';
 import { ko } from 'date-fns/esm/locale';
 import styled from 'styled-components';
@@ -28,15 +28,29 @@ export default function CustomDatePicker(props) {
     setSelectedDate(date);
   };
 
-  const datePickerClose = () => {
+  // cancel button
+  const datePickerCancel = () => {
     resetSelectedDate();
+    props.setIsOpen(false);
   };
+
+  const datePickerSelect = () => {
+    props.setIsOpen(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      resetSelectedDate();
+    };
+  }, [resetSelectedDate]);
 
   return (
     <DatePickerWrapper
       locale={ko}
       dateFormat="yyyy-MM-dd"
       selected={selectedDate}
+      open={props.isOpen}
+      minDate={new Date()}
       onChange={date => handleDaySelect(date)}
       shouldCloseOnSelect={false}
       onMonthChange={handleMonthChange}
@@ -51,11 +65,11 @@ export default function CustomDatePicker(props) {
         nextMonthButtonDisabled,
       }) => (
         <CustomHeaderContainer>
-          <MonthButton onClick={decreaseMonth}>{`<`}</MonthButton>
+          <MonthButton type="button" onClick={decreaseMonth}>{`<`}</MonthButton>
           <ShowSelectYearAndMonth>
             {`${getYear(date)}.${('0' + (getMonth(date) + 1)).slice(-2)}`}
           </ShowSelectYearAndMonth>
-          <MonthButton onClick={increaseMonth}>{`>`}</MonthButton>
+          <MonthButton type="button" onClick={increaseMonth}>{`>`}</MonthButton>
         </CustomHeaderContainer>
       )}
       calendarClassName="custom-calender"
@@ -66,10 +80,12 @@ export default function CustomDatePicker(props) {
       }
     >
       <DatePickerFooter>
-        <SelectButton type="button" onClick={datePickerClose}>
+        <CancelButton type="button" onClick={datePickerCancel}>
           취소
+        </CancelButton>
+        <SelectButton type="button" onClick={datePickerSelect}>
+          확인
         </SelectButton>
-        <SelectButton type="button">확인</SelectButton>
       </DatePickerFooter>
     </DatePickerWrapper>
   );
@@ -115,15 +131,40 @@ const DatePickerFooter = styled.div`
   display: flex;
   justify-content: flex-end;
   height: 100px;
-  padding: 0 70px;
+  padding: 0 20px;
   padding-top: 36px;
   background-color: ${theme.colors.black};
 `;
 
+const CancelButton = styled.button`
+  width: 120px;
+  height: 50px;
+  border-radius: 10px;
+  border: none;
+  background-color: ${theme.colors.cancleRed};
+
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+`;
+
 const SelectButton = styled.button`
-  width: 70px;
-  height: 30px;
+  width: 120px;
+  height: 50px;
   margin-left: 10px;
+  border-radius: 10px;
+  border: none;
+  background-color: ${theme.colors.blue};
+
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
 `;
 
 const CustomHeaderContainer = styled.div`
@@ -147,7 +188,15 @@ const MonthButton = styled.button`
 `;
 
 const ShowSelectYearAndMonth = styled.div`
-  color: white;
+  color: ${theme.colors.white};
+  text-shadow: 0px 4px 20px rgba(0, 0, 0, 0.25);
+  padding-top: 6px;
+
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 300;
+  line-height: normal;
 `;
 
 // date picker top
@@ -160,11 +209,26 @@ const DatePickerTop = styled.div`
 `;
 
 const ShowYear = styled.div`
-  font-size: 20px;
+  margin-bottom: 10px;
+  color: ${theme.colors.pureBlack};
+
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 300;
+  line-height: normal;
+  text-align: left;
 `;
 
 const ShowDate = styled.div`
-  font-size: 30px;
+  color: ${theme.colors.pureBlack};
+
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.tab};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  text-align: left;
 `;
 
 const DatePickerBody = styled.div`
@@ -173,10 +237,12 @@ const DatePickerBody = styled.div`
 
 const DatePickerInner = styled(CalendarContainer)`
   position: fixed;
-  top: 0;
+  top: 5%;
   left: 50%;
   z-index: 1000;
   transform: translateX(-50%);
+
+  border: none;
 `;
 
 const DatePickerContainer = styled.div`

--- a/frontend/src/components/datePicker/datePickerRent.js
+++ b/frontend/src/components/datePicker/datePickerRent.js
@@ -1,0 +1,260 @@
+import { useEffect, useState } from 'react';
+import DatePicker, { CalendarContainer } from 'react-datepicker';
+import { ko } from 'date-fns/esm/locale';
+import styled from 'styled-components';
+import { getYear, getMonth } from 'date-fns';
+import '../../styles/datepickerRent.css';
+
+import theme from '../../styles/Theme';
+import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
+import { endSelect } from './../../atom/endSelect';
+require('react-datepicker/dist/react-datepicker.css');
+
+// 날짜 선택창을 직접 만들기를 요청하여
+// react-datepicker 라이브러리를 활용하여 제작
+export default function CustomDatePickerRent(props) {
+  const [selectedDate, setSelectedDate] = useRecoilState(endSelect); // 현재 선택한 날짜
+  const resetSelectedDate = useResetRecoilState(endSelect); // 선택 초기화
+  const [month, setMonth] = useState(new Date().getMonth() + 1); // 현재 선택한 월
+
+  // 월을 바꿀 때 일어나는 함수
+  const handleMonthChange = date => {
+    setMonth(date.getMonth());
+    console.log(month);
+  };
+
+  // 일을 바꿀 때 일어나는 함수
+  const handleDaySelect = date => {
+    setSelectedDate(date);
+  };
+
+  // cancel button
+  const datePickerCancel = () => {
+    resetSelectedDate();
+    props.setIsOpen(false);
+  };
+
+  const datePickerSelect = () => {
+    props.setIsOpen(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      resetSelectedDate();
+    };
+  }, [resetSelectedDate]);
+
+  return (
+    <DatePickerWrapper
+      locale={ko}
+      dateFormat="yyyy-MM-dd"
+      selected={selectedDate}
+      open={props.isOpen}
+      minDate={new Date()}
+      disabled={props.disabled}
+      onChange={date => handleDaySelect(date)}
+      shouldCloseOnSelect={false}
+      onMonthChange={handleMonthChange}
+      calendarContainer={MyContainer}
+      wrapperClassName="datepicker-container"
+      renderCustomHeader={({
+        date,
+        changeYear,
+        decreaseMonth,
+        increaseMonth,
+        prevMonthButtonDisabled,
+        nextMonthButtonDisabled,
+      }) => (
+        <CustomHeaderContainer>
+          <MonthButton type="button" onClick={decreaseMonth}>{`<`}</MonthButton>
+          <ShowSelectYearAndMonth>
+            {`${getYear(date)}.${('0' + (getMonth(date) + 1)).slice(-2)}`}
+          </ShowSelectYearAndMonth>
+          <MonthButton type="button" onClick={increaseMonth}>{`>`}</MonthButton>
+        </CustomHeaderContainer>
+      )}
+      calendarClassName="custom-calender"
+      dayClassName={day =>
+        day.getDate() === selectedDate.getDate()
+          ? 'selectedDay'
+          : 'unSelectedDay'
+      }
+    >
+      <DatePickerFooter>
+        <SelectButton type="button" onClick={datePickerSelect}>
+          확인
+        </SelectButton>
+        <CancelButton type="button" onClick={datePickerCancel}>
+          취소
+        </CancelButton>
+      </DatePickerFooter>
+    </DatePickerWrapper>
+  );
+}
+
+const DatePickerWrapper = styled(DatePicker)`
+  border: none;
+  background-color: transparent;
+  color: transparent;
+  outline: none;
+
+  width: 0;
+`;
+
+function MyContainer({ className, children }) {
+  const selectedDate = useRecoilValue(endSelect);
+  const week = ['일', '월', '화', '수', '목', '금', '토'];
+
+  // 날짜 선택 창 상단에 보이는 부분
+  // 선택한 년월일을 확인할 수 있음
+  return (
+    <DatePickerContainer>
+      <DatePickerInner className={className}>
+        <DatePickerTop>
+          <ShowYear>{`${selectedDate.getFullYear()}년`}</ShowYear>
+          <ShowDate>{`${
+            selectedDate.getMonth() + 1
+          }월 ${selectedDate.getDate()}일 ${
+            week[selectedDate.getDay()]
+          }요일`}</ShowDate>
+        </DatePickerTop>
+        <DatePickerBody>{children}</DatePickerBody>
+      </DatePickerInner>
+    </DatePickerContainer>
+  );
+}
+
+const DatePickerFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  height: 130px;
+  padding: 0 130px;
+  padding-top: 36px;
+  background-color: ${theme.colors.black};
+
+  border: none;
+  border-bottom-left-radius: 20px;
+  border-bottom-right-radius: 20px;
+`;
+
+const CancelButton = styled.button`
+  width: 100px;
+  height: 40px;
+  border-radius: 20px;
+  border: none;
+  background-color: ${theme.colors.grey};
+
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+`;
+
+const SelectButton = styled.button`
+  width: 100px;
+  height: 40px;
+  margin-right: 20px;
+  border-radius: 20px;
+  border: none;
+  background-color: ${theme.colors.blue};
+
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+`;
+
+const CustomHeaderContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 67px;
+  padding-bottom: 38px;
+  background-color: ${theme.colors.black};
+`;
+
+const MonthButton = styled.button`
+  margin: 0 90px;
+  background-color: transparent;
+  border: none;
+  color: white;
+  font-size: 20px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const ShowSelectYearAndMonth = styled.div`
+  color: ${theme.colors.white};
+  text-shadow: 0px 4px 20px rgba(0, 0, 0, 0.25);
+  padding-top: 6px;
+
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 300;
+  line-height: normal;
+`;
+
+// date picker top
+const DatePickerTop = styled.div`
+  box-sizing: border-box;
+  width: 490px;
+  height: 130px;
+  padding: 30px 20px;
+  background-color: ${theme.colors.white};
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+`;
+
+const ShowYear = styled.div`
+  margin-bottom: 10px;
+  color: ${theme.colors.pureBlack};
+
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-style: normal;
+  font-weight: 300;
+  line-height: normal;
+  text-align: center;
+`;
+
+const ShowDate = styled.div`
+  color: ${theme.colors.pureBlack};
+
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.tab};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  text-align: center;
+`;
+
+const DatePickerBody = styled.div`
+  position: relative;
+`;
+
+const DatePickerInner = styled(CalendarContainer)`
+  position: fixed;
+  top: -30%;
+  left: 50%;
+  z-index: 1000;
+  transform: translateX(-50%);
+
+  border: none;
+`;
+
+const DatePickerContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+`;

--- a/frontend/src/components/eachItem/EachCabinet.js
+++ b/frontend/src/components/eachItem/EachCabinet.js
@@ -1,14 +1,16 @@
 import styled from 'styled-components';
 import theme from '../../styles/Theme';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { cabinet, cabinetModal } from '../../atom/cabinet';
 import useConfirm from '../../hook/useConfirm';
 import { request } from '../../utils/axios';
 import ConfirmMessage from '../../constants/ConfirmMessage';
+import { user } from '../../atom/user';
 
 // 사물함 대여페이지에서 사용하는 사물함들
 function EachCabinet({ eachCabinet }) {
-  const myName = '김진호'; // 추후에 user atom에서 가져와서 사용할 예정
+  const userinfo = useRecoilValue(user);
+  const myName = userinfo.name;
   const approveManagerMent = `관리자 승인 후\n사용 가능합니다.`;
 
   const setCurrentIndex = useSetRecoilState(cabinetModal); // 모달 창 작동을 위해
@@ -21,7 +23,7 @@ function EachCabinet({ eachCabinet }) {
       targetId: 'B731070',
     };
     try {
-      const response = await request('post', '/locker/return', body);
+      await request('post', '/locker/return', body);
 
       // 선택한 사물함을 반납함 (myRent -> unrent)
       const updatedList = cabinetList.map(cabinet => {

--- a/frontend/src/components/eachItem/EachUmbrella.js
+++ b/frontend/src/components/eachItem/EachUmbrella.js
@@ -1,15 +1,17 @@
 import styled from 'styled-components';
 import theme from '../../styles/Theme';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { umbrella, umbrellaModal } from '../../atom/umbrella';
 import { request } from '../../utils/axios';
 import useConfirm from '../../hook/useConfirm';
 import moment from 'moment';
 import ConfirmMessage from '../../constants/ConfirmMessage';
+import { user } from '../../atom/user';
 
 // 우산 대여페이지에서 사용하는 우산들
 function EachUmbrella({ eachUmbrella }) {
-  const myName = '김진호'; // 추후에 user atom에서 가져와서 사용할 예정
+  const userinfo = useRecoilValue(user);
+  const myName = userinfo.name;
 
   const setCurrentIndex = useSetRecoilState(umbrellaModal); // 모달 창 관리를 위해
   const [umbrellaList, setUmbrellaList] = useRecoilState(umbrella); // 우산 정보를 변경하기 위해

--- a/frontend/src/components/layout/Layout.js
+++ b/frontend/src/components/layout/Layout.js
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import Header from '../header/Header';
+import { Outlet, useLocation } from 'react-router-dom';
+import Footer from './../main/Footer';
+
+function Layout() {
+  const location = useLocation();
+  const url = location.pathname.split('/');
+  const page = url[1];
+
+  return (
+    <Container>
+      <Header background={page ? 1 : 0} />
+      <Outlet />
+      <Footer />
+    </Container>
+  );
+}
+
+export default Layout;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  margin: 0 auto;
+`;

--- a/frontend/src/components/manage/CabinetRentWindow.js
+++ b/frontend/src/components/manage/CabinetRentWindow.js
@@ -162,5 +162,5 @@ const ViewApplyModal = styled.div`
   left: 0px;
   top: 0px;
   background-color: rgba(0, 0, 0, 0.6);
-  z-index: 1;
+  z-index: 101;
 `;

--- a/frontend/src/components/noticeboard/Restaurant.js
+++ b/frontend/src/components/noticeboard/Restaurant.js
@@ -48,7 +48,11 @@ function Restaurant(props) {
         <Header>맛집 지도</Header>
         <EnrollButton ref={enrollModal}>
           맛집 등록
-          {enrollOpen && <EnrollRestaurant />}
+          {enrollOpen && (
+            <ViewModal view={enrollOpen ? 1 : 0}>
+              <EnrollRestaurant close={close} />
+            </ViewModal>
+          )}
         </EnrollButton>
         <Map
           /* 디폴트는 학교의 위도 경도 */
@@ -175,4 +179,16 @@ const EnrollButton = styled.div`
   font-style: normal;
   font-weight: 600;
   font-size: ${theme.fontSizes.label};
+`;
+
+const ViewModal = styled.div`
+  display: ${props => (props.view ? 'block' : 'none')};
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 101;
 `;

--- a/frontend/src/components/popup/ApplyModal.js
+++ b/frontend/src/components/popup/ApplyModal.js
@@ -33,7 +33,7 @@ export default function ApplyModal(props) {
   const closeModalFunc = useResetRecoilState(applyType[itemName].index);
   // 모달 창 종료를 위해 모달 오픈 여부를 모두 false로 리셋함
   const modalRef = useRef(null);
-  const closeModal = useCloseModal(modalRef, closeModalFunc); // 모달 창 닫음을 수행
+  useCloseModal(modalRef, closeModalFunc); // 모달 창 닫음을 수행
 
   const [itemList, setItemList] = useRecoilState(applyType[itemName].item); // 대여 상태 변환
   const [date, setDate] = useState(); // 날짜 선택을 위해
@@ -56,7 +56,7 @@ export default function ApplyModal(props) {
       // 사물함일 경우 승인 대기 상태로 전환
       if (itemName === '사물함') {
         try {
-          const response = request('post', '/locker/rent', body);
+          request('post', '/locker/rent', body);
           const updatedList = itemList.map(cabinet => {
             if (cabinet.cabinetNumber === itemNumber) {
               return {
@@ -77,7 +77,7 @@ export default function ApplyModal(props) {
       } else {
         // 우산일 경우 내가 대여 상태로 변환
         try {
-          const response = request('post', '/umbrella/rent', body);
+          request('post', '/umbrella/rent', body);
           const updatedList = itemList.map(umbrella => {
             if (umbrella.umbrellaNumber === itemNumber) {
               return {
@@ -123,7 +123,12 @@ export default function ApplyModal(props) {
           </InputRow>
           <InputRow>
             <Label>대여일자</Label>
-            <Input type="date" value={startDay} disabled={startDayDisabled} />
+            <Input
+              type="date"
+              value={startDay}
+              disabled={startDayDisabled}
+              required
+            />
           </InputRow>
           <InputRow>
             <Label>반납일자</Label>
@@ -132,6 +137,7 @@ export default function ApplyModal(props) {
               value={endDay !== undefined ? endDay : date || ''}
               onChange={onChange}
               disabled={endDayDisabled}
+              required
             />
           </InputRow>
         </ApplyCabinetModalContent>
@@ -146,7 +152,7 @@ const ApplyCabinetModalContainer = styled.div`
   flex-direction: column;
   align-items: center;
 
-  position: fixed;
+  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/frontend/src/components/popup/ApplyModal.js
+++ b/frontend/src/components/popup/ApplyModal.js
@@ -2,12 +2,17 @@ import styled from 'styled-components';
 import theme from '../../styles/Theme';
 import Button from '../util/Button';
 import { useRecoilState, useResetRecoilState } from 'recoil';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useCloseModal from '../../hook/useCloseModal';
 import { applyType } from '../../constants/ApplyType';
 import useConfirm from '../../hook/useConfirm';
 import { request } from '../../utils/axios';
 import ConfirmMessage from '../../constants/ConfirmMessage';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import CustomDatePickerRent from '../datePicker/datePickerRent';
+import { faCalendarDays } from '@fortawesome/free-regular-svg-icons';
+import { endSelect } from '../../atom/endSelect';
+import moment from 'moment';
 
 // 대여 신청 팝업 창
 /*
@@ -20,27 +25,23 @@ import ConfirmMessage from '../../constants/ConfirmMessage';
   endDayDisabled: 대여 반납일 선택불가여부 (사물함 선택 가능, 우산은 7일로 고정)
 */
 export default function ApplyModal(props) {
-  const {
-    itemName,
-    itemNumber,
-    lender,
-    startDay,
-    endDay,
-    startDayDisabled,
-    endDayDisabled,
-  } = props;
+  const { itemName, itemNumber, lender, startDay, endDay } = props;
 
   const closeModalFunc = useResetRecoilState(applyType[itemName].index);
   // 모달 창 종료를 위해 모달 오픈 여부를 모두 false로 리셋함
   const modalRef = useRef(null);
   useCloseModal(modalRef, closeModalFunc); // 모달 창 닫음을 수행
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
 
   const [itemList, setItemList] = useRecoilState(applyType[itemName].item); // 대여 상태 변환
-  const [date, setDate] = useState(); // 날짜 선택을 위해
 
-  const onChange = event => {
-    setDate(event.target.value);
-  };
+  const [end, setEnd] = useRecoilState(endSelect);
+
+  useEffect(() => {
+    if (endDay !== undefined) {
+      setEnd(endDay);
+    }
+  }, []);
 
   // 대여 신청
   // 한 사람 당 한 개만 신청할 수 있음
@@ -63,7 +64,7 @@ export default function ApplyModal(props) {
                 ...cabinet,
                 status: 'waiting',
                 start: startDay,
-                end: date,
+                end,
                 lender,
               };
             } else {
@@ -101,6 +102,11 @@ export default function ApplyModal(props) {
     }
   };
 
+  const onSubmit = event => {
+    event.preventDefault();
+    apply();
+  };
+
   // 신청 확인 창을 띄운다.
   const apply = useConfirm(
     ConfirmMessage.rentItem,
@@ -112,7 +118,7 @@ export default function ApplyModal(props) {
     <>
       <ApplyCabinetModalContainer ref={modalRef}>
         <Header>{itemName} 대여 신청</Header>
-        <ApplyCabinetModalContent>
+        <ApplyCabinetModalContent onSubmit={onSubmit}>
           <InputRow>
             <Label>{itemName} 번호</Label>
             <Input value={itemNumber} disabled />
@@ -123,25 +129,41 @@ export default function ApplyModal(props) {
           </InputRow>
           <InputRow>
             <Label>대여일자</Label>
-            <Input
-              type="date"
-              value={startDay}
-              disabled={startDayDisabled}
-              required
-            />
+            <DateShow>
+              <Day>{props.startDay.year()}</Day>/
+              <Day>
+                {(props.startDay.month() + 1).toString().padStart(2, '0')}
+              </Day>
+              /<Day>{props.startDay.date().toString().padStart(2, '0')}</Day>
+            </DateShow>
           </InputRow>
           <InputRow>
             <Label>반납일자</Label>
-            <Input
-              type="date"
-              value={endDay !== undefined ? endDay : date || ''}
-              onChange={onChange}
-              disabled={endDayDisabled}
-              required
+            <DateShow>
+              <Day end={1}>{moment(end).year()}</Day>/
+              <Day end={1}>
+                {(moment(end).month() + 1).toString().padStart(2, '0')}
+              </Day>
+              /
+              <Day end={1}>
+                {moment(end).date().toString().padStart(2, '0')}
+              </Day>
+            </DateShow>
+            <CustomDatePickerRent
+              isOpen={isDatePickerOpen}
+              setIsOpen={setIsDatePickerOpen}
             />
+            <DatePickerButton
+              view={endDay === undefined ? 1 : 0}
+              type="button"
+              onClick={() => setIsDatePickerOpen(true)}
+            >
+              <FontAwesomeIcon icon={faCalendarDays} />
+            </DatePickerButton>
           </InputRow>
+
+          <ApplyButton buttonName="신청하기" buttonType="submit" />
         </ApplyCabinetModalContent>
-        <ApplyButton buttonName="신청하기" onClick={apply} />
       </ApplyCabinetModalContainer>
     </>
   );
@@ -173,7 +195,7 @@ const Header = styled.header`
   text-align: center;
 `;
 
-const ApplyCabinetModalContent = styled.div`
+const ApplyCabinetModalContent = styled.form`
   width: 340px;
   margin: 32px 0;
   padding: 8px 0px;
@@ -181,7 +203,9 @@ const ApplyCabinetModalContent = styled.div`
 
 const InputRow = styled.div`
   display: flex;
+  position: relative;
   align-items: center;
+  height: 24px;
   margin-bottom: 16px;
 `;
 
@@ -210,4 +234,48 @@ const Input = styled.input`
 const ApplyButton = styled(Button)`
   width: 320px;
   height: 40px;
+
+  margin-top: 30px;
+`;
+
+const DateShow = styled.div`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+
+  width: 100%;
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.font_normal};
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+`;
+
+const Day = styled.span`
+  padding: 3px 10px;
+
+  border-radius: 20px;
+  background: ${props => (!props.end ? theme.colors.white : 'transperent')};
+
+  color: ${props => (!props.end ? theme.colors.pureBlack : theme.colors.blue)};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.font_normal};
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+`;
+
+const DatePickerButton = styled.button`
+  display: ${props => (props.view ? 'block' : 'none')};
+  position: absolute;
+  top: -16%;
+  right: -7%;
+  background-color: transparent;
+  border: none;
+  color: ${theme.colors.purple};
+  font-size: 20px;
+  &:hover {
+    cursor: pointer;
+  }
 `;

--- a/frontend/src/components/popup/ApproveModal.js
+++ b/frontend/src/components/popup/ApproveModal.js
@@ -101,7 +101,7 @@ const ApplyCabinetModalContainer = styled.div`
   flex-direction: column;
   align-items: center;
 
-  position: fixed;
+  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -111,6 +111,7 @@ const ApplyCabinetModalContainer = styled.div`
   height: 400px;
   padding: 32px 64px;
   background-color: ${theme.colors.black};
+  border-radius: 20px;
 `;
 
 const Header = styled.header`

--- a/frontend/src/components/popup/EnrollRestaurant.js
+++ b/frontend/src/components/popup/EnrollRestaurant.js
@@ -9,6 +9,7 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import { useRecoilState } from 'recoil';
 import curEnrollRestaurant from '../../atom/curEnrollRestaurant';
 import useScrollGradient from '../../hook/useScrollGradient';
+import useCloseModal from '../../hook/useCloseModal';
 
 function EnrollRestaurant(props) {
   const { kakao } = window;
@@ -16,6 +17,9 @@ function EnrollRestaurant(props) {
   const [places, setPlaces] = useState([]);
   const [keyword, setKeyword] = useInput('');
   const [current, setCurrent] = useRecoilState(curEnrollRestaurant);
+
+  const modalRef = useRef(null);
+  useCloseModal(modalRef, props.close);
 
   const scrollRef = useRef(null);
   const { showGradient, showGradientTop } = useScrollGradient(scrollRef);
@@ -64,7 +68,7 @@ function EnrollRestaurant(props) {
   }, [current]);
 
   return (
-    <Container>
+    <Container ref={modalRef}>
       <SearchSection>
         <Header>
           <Title>장소 검색</Title>
@@ -141,7 +145,7 @@ export default EnrollRestaurant;
 
 const Container = styled.div`
   display: flex;
-  position: fixed;
+  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/frontend/src/components/popup/ScheduleModal.js
+++ b/frontend/src/components/popup/ScheduleModal.js
@@ -7,20 +7,37 @@ import { useRecoilValue } from 'recoil';
 import { date } from '../../atom/date';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCalendarDays } from '@fortawesome/free-solid-svg-icons';
+import { request } from '../../utils/axios';
+import useSelect from './../../hook/useSelect';
+import useInput from './../../hook/useInput';
 
 // 일정 캘린더 내 일정 작성을 누를 때 뜨는 팝업창
 export default function ScheduleModal(props) {
-  const [selectOption, setSelectOption] = useState('default'); // 학술, 친목, 학교행사 선택
+  const [selectOption, setSelectOption] = useSelect('default'); // 학술, 친목, 학교행사 선택
+  const [title, setTitle] = useInput(''); // 일정제목
+  const [desc, setDesc] = useInput(''); // 세부내용
+  const [isOpen, setIsOpen] = useState(false);
 
-  const onChangeSelect = event => {
-    setSelectOption(event.target.value);
+  const selectDay = useRecoilValue(date);
+
+  // 일정 저장하는 함수
+  const onSubmit = async event => {
+    const body = {
+      title,
+      date: selectDay,
+      option: selectOption,
+      desc,
+    };
+    try {
+      await request('post', '/calendar', body);
+    } catch (error) {
+      console.log(error);
+    }
   };
 
-  const onSubmit = event => {
-    event.preventDefault();
+  const openDatePicker = () => {
+    setIsOpen(true);
   };
-
-  const selectDate = useRecoilValue(date); // 선택된 날짜 가져오기
 
   return (
     <ScheduleModalContainer>
@@ -29,7 +46,7 @@ export default function ScheduleModal(props) {
         <SelectScheduleType
           value={selectOption}
           color={theme.scheduleTypeColor[selectOption]}
-          onChange={onChangeSelect}
+          onChange={setSelectOption}
         >
           <SelectScheduleTypeOption value="default" style={{ display: 'none' }}>
             일정 종류
@@ -57,18 +74,18 @@ export default function ScheduleModal(props) {
       <ScheduleInputContainer onSubmit={onSubmit}>
         <InputRow>
           <InputRowLable>일정 제목</InputRowLable>
-          <Input required height={30} />
+          <Input required height={30} value={title} onChange={setTitle} />
         </InputRow>
         <InputRow>
           <InputRowLable>날짜</InputRowLable>
           <DatePickerContainer>
-            <CustomDatePicker />
-            <DateIcon icon={faCalendarDays} />
+            <CustomDatePicker isOpen={isOpen} setIsOpen={setIsOpen} />
+            <DateIcon icon={faCalendarDays} onClick={openDatePicker} />
           </DatePickerContainer>
         </InputRow>
         <InputRow>
           <InputRowLable>세부사항</InputRowLable>
-          <Input required height={78} />
+          <TextArea required height={120} value={desc} onChange={setDesc} />
         </InputRow>
         <ButtonContainer>
           <CancleButton buttonName="취소" onClick={props.closeModal} />
@@ -84,7 +101,7 @@ const ScheduleModalContainer = styled.div`
   top: 50%;
   left: 50%;
   z-index: 100;
-  transform: translate(-50%, 0);
+  transform: translate(-50%, -50%);
   width: 620px;
   height: 750px;
   background-color: ${theme.colors.black};
@@ -102,6 +119,8 @@ const ScheduleModalHeader = styled.div`
 
 const ScheduleModalTitle = styled.div`
   padding: 20px;
+  color: ${theme.colors.black};
+
   font-family: 'GmarketSansMedium';
   font-weight: 500;
   font-size: 30px;
@@ -160,6 +179,21 @@ const Input = styled.input`
   border: none;
   border-bottom: 1px solid rgba(237, 240, 248, 0.7);
   outline: none;
+
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: 20px;
+  font-weight: 300;
+`;
+
+const TextArea = styled.textarea`
+  width: 580px;
+  height: ${props => `${props.height}px`};
+  background-color: transparent;
+  border: none;
+  border-bottom: 1px solid rgba(237, 240, 248, 0.7);
+  outline: none;
+  resize: none;
 
   color: ${theme.colors.white};
   font-family: 'Pretendard';

--- a/frontend/src/components/popup/noticeLayerPopup.js
+++ b/frontend/src/components/popup/noticeLayerPopup.js
@@ -59,7 +59,7 @@ function NoticeLayerPopup() {
               {notificationMessage(notice.type, notice.payload)}
             </NoticeTitle>
             <NoticeDesc>안녕하세요</NoticeDesc>
-            <NoticeTime>{`${calculateDueDate(notice.time)} 전`}</NoticeTime>
+            <NoticeTime>{`${calculateDueDate(notice.time)}`}</NoticeTime>
           </NoticeContent>
         ))}
       </NoticeSection>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,10 +5,10 @@ import Theme from './styles/Theme';
 import { ThemeProvider } from 'styled-components';
 import reportWebVitals from './reportWebVitals';
 
-import Routes from './Routes';
-
 import { worker } from './mocks/browsers';
 import { RecoilRoot } from 'recoil';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
 
 // msw 실행을 위해
 if (process.env.NODE_ENV === 'development') {
@@ -17,14 +17,16 @@ if (process.env.NODE_ENV === 'development') {
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <>
-    <GlobalStyle />
+  <React.StrictMode>
     <ThemeProvider theme={Theme}>
-      <RecoilRoot>
-        <Routes />
-      </RecoilRoot>
+      <GlobalStyle />
+      <BrowserRouter>
+        <RecoilRoot>
+          <App />
+        </RecoilRoot>
+      </BrowserRouter>
     </ThemeProvider>
-  </>,
+  </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/frontend/src/pages/CabinetRent.js
+++ b/frontend/src/pages/CabinetRent.js
@@ -10,8 +10,8 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import { cabinet, cabinetModal, currentCabinetIndex } from '../atom/cabinet';
 import Header from '../components/header/Header';
 import Navigation from '../components/header/Navigation';
-import { request } from '../utils/axios';
 import useFetch from '../hook/useFetch';
+import { user } from '../atom/user';
 
 // 사물함 대여 페이지
 export default function CabinetRent(props) {
@@ -20,16 +20,14 @@ export default function CabinetRent(props) {
   const currentIndex = useRecoilValue(currentCabinetIndex); // 모달 백드롭 때문에
 
   const resetCabinet = useResetRecoilState(cabinet); // 사물함 상태 초기화
-
-  const myName = '김진호';
-
+  const userinfo = useRecoilValue(user); // 내 정보 가져오기 위해
   const checkMyRent = useMyRent(); // 내가 대여 처리
 
   const { data, loading, error } = useFetch('/locker');
 
   useEffect(() => {
     if (data) {
-      const cabinetListIncludeMyRent = checkMyRent(data, myName);
+      const cabinetListIncludeMyRent = checkMyRent(data, userinfo.name);
       setInit(cabinetListIncludeMyRent);
       setCabinetList(init);
     }
@@ -76,7 +74,7 @@ export default function CabinetRent(props) {
                 <ApplyModal
                   itemName={`사물함`}
                   itemNumber={item.cabinetNumber}
-                  lender={myName}
+                  lender={userinfo.name}
                   startDay={moment(new Date()).format('yyyy-MM-DD')}
                   endDay={undefined}
                   startDayDisabled={true}
@@ -130,11 +128,11 @@ const CabinetGrid = styled.div`
 const ViewApplyModal = styled.div`
   display: ${props => (props.view ? 'block' : 'none')};
   position: fixed;
-
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
-  left: 0px;
-  top: 0px;
+
   background-color: rgba(0, 0, 0, 0.6);
-  z-index: 1;
+  z-index: 101;
 `;

--- a/frontend/src/pages/CabinetRent.js
+++ b/frontend/src/pages/CabinetRent.js
@@ -8,7 +8,6 @@ import moment from 'moment';
 import useMyRent from '../hook/useMyRent';
 import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import { cabinet, cabinetModal, currentCabinetIndex } from '../atom/cabinet';
-import Header from '../components/header/Header';
 import Navigation from '../components/header/Navigation';
 import useFetch from '../hook/useFetch';
 import { user } from '../atom/user';
@@ -52,7 +51,6 @@ export default function CabinetRent(props) {
 
   return (
     <CabinetRentContainer>
-      <Header background={true} />
       <Navigation
         ancestorMenuTree={ancestorMenuTree}
         currentTabContents={currentTabContents}
@@ -92,7 +90,7 @@ export default function CabinetRent(props) {
 const CabinetRentContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `;
 
 const CabinetCurrentState = styled.div`

--- a/frontend/src/pages/CabinetRent.js
+++ b/frontend/src/pages/CabinetRent.js
@@ -35,6 +35,7 @@ export default function CabinetRent(props) {
     return () => {
       resetCabinet();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
   const modalRef = useRef(null);
@@ -75,10 +76,8 @@ export default function CabinetRent(props) {
                   itemName={`사물함`}
                   itemNumber={item.cabinetNumber}
                   lender={userinfo.name}
-                  startDay={moment(new Date()).format('yyyy-MM-DD')}
+                  startDay={moment(new Date())}
                   endDay={undefined}
-                  startDayDisabled={true}
-                  endDayDisabled={false}
                 />
               ),
           )}

--- a/frontend/src/pages/Calendar.js
+++ b/frontend/src/pages/Calendar.js
@@ -163,7 +163,11 @@ function Calendar() {
         </CalendarTopContent>
         <AddScheduleModal ref={modalRef}>
           {`일정추가 +`}
-          {modalOpen && <ScheduleModal closeModal={closeModal} />}
+          {modalOpen && (
+            <ViewModal view={modalOpen}>
+              <ScheduleModal closeModal={closeModal} />
+            </ViewModal>
+          )}
         </AddScheduleModal>
       </CalendarTop>
       <CalendarMain>
@@ -237,10 +241,6 @@ const AddScheduleModal = styled.div`
   font-weight: 600;
   font-size: ${theme.fontSizes.subtitle};
   line-height: 36px;
-
-  &:hover {
-    cursor: pointer;
-  }
 `;
 
 const CalendarMain = styled.div`
@@ -317,17 +317,14 @@ const CalendarPlanButton = styled.button`
   cursor: pointer;
 `;
 
-const Backdrop = styled.div`
+const ViewModal = styled.div`
   display: ${props => (props.view ? 'block' : 'none')};
   position: fixed;
-  top: 0;
-  left: 0;
+
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 99;
-
-  &:hover {
-    cursor: alias;
-  }
+  left: 0px;
+  top: 0px;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 101;
 `;

--- a/frontend/src/pages/Calendar.js
+++ b/frontend/src/pages/Calendar.js
@@ -5,7 +5,6 @@ import data from '../data/data.json';
 import theme from '../styles/Theme';
 import ScheduleModal from '../components/popup/ScheduleModal';
 import Title from '../components/header/Title';
-import Header from '../components/header/Header';
 import useModal from '../hook/useModal';
 import ScheduleModalSaved from '../components/popup/ScheduleModalSaved';
 
@@ -152,7 +151,6 @@ function Calendar() {
 
   return (
     <MainContainer>
-      <Header background={true} />
       <Title titleName="일정 캘린더" />
       <CalendarTop>
         <Blank />
@@ -200,7 +198,7 @@ const CalendarButton = styled.button`
 const MainContainer = styled.div`
   position: relative;
   width: ${theme.componentSize.maxWidth};
-  height: 100vh;
+  height: 100%;
   margin: 0 auto;
   place-items: center;
   align-items: center;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -12,7 +12,6 @@ import { request } from '../utils/axios';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { user } from '../atom/user';
 import Title from '../components/header/Title';
-import Header from '../components/header/Header';
 import agree from '../atom/agree';
 
 // 로그인
@@ -52,7 +51,6 @@ export default function Login(props) {
 
   return (
     <LoginContainer>
-      <Header background={true} />
       <Title titleName="로그인" />
       <InputForm onSubmit={handleSubmit(onSubmit)}>
         <InputMemberInfo
@@ -101,7 +99,7 @@ export default function Login(props) {
 
 const LoginContainer = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `;
 
 const InputForm = styled.form`

--- a/frontend/src/pages/Main.js
+++ b/frontend/src/pages/Main.js
@@ -1,19 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
-import Header from '../components/header/Header';
 import Banner from '../components/main/Banner';
 import Activity from '../components/main/Activity';
 import NumberTable from '../components/main/NumberTable';
 import HongMap from '../components/main/HongMap';
 import JoinHICC from '../components/main/JoinHICC';
-import Footer from '../components/main/Footer';
 import Projects from '../components/main/Projects';
 import RecentNews from '../components/main/RecentNews';
 
 function Main() {
   return (
     <MainContainer>
-      <Header background={false} />
       <Banner />
       <Activity />
       <NumberTable />
@@ -21,7 +18,6 @@ function Main() {
       <Projects />
       <HongMap />
       <JoinHICC />
-      <Footer />
     </MainContainer>
   );
 }
@@ -29,7 +25,7 @@ function Main() {
 export default Main;
 
 const MainContainer = styled.div`
-  height: 100vh;
+  height: 100%;
   width: 100%;
   margin: 0 auto;
   place-items: center;

--- a/frontend/src/pages/Manage.js
+++ b/frontend/src/pages/Manage.js
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { ManageMenu } from '../constants/ManageMenu';
 import theme from '../styles/Theme';
-import Header from '../components/header/Header';
 import ManageTab from '../components/header/ManageTab';
 import { useRecoilValue } from 'recoil';
 import { manageTab } from '../atom/tab/manage';
@@ -13,7 +12,6 @@ function Manage(props) {
 
   return (
     <ManageContainer>
-      <Header background={true} />
       <ManageTab />
       {ManageMenu[menu]}
     </ManageContainer>
@@ -24,6 +22,6 @@ export default Manage;
 
 const ManageContainer = styled.div`
   width: ${theme.componentSize.maxWidth};
-  height: 100vh;
+  height: 100%;
   margin: 0 auto;
 `;

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import theme from '../styles/Theme';
 import { TabContentByIndexMypage } from '../constants/TabContentByIndexMypage';
 import Tab from '../components/header/Tab';
-import Header from '../components/header/Header';
 
 function Mypage() {
   const MyComments = () => {
@@ -38,7 +37,6 @@ function Mypage() {
 
   return (
     <MypageContainer>
-      <Header background={true} />
       <Tab
         ancestorMenuTree={ancestorMenuTree}
         currentTabContents={currentTabContents}
@@ -54,6 +52,6 @@ export default Mypage;
 
 const MypageContainer = styled.div`
   width: ${theme.componentSize.maxWidth};
-  height: 100vh;
+  height: 1000px;
   margin: 0 auto;
 `;

--- a/frontend/src/pages/Noticeboard.js
+++ b/frontend/src/pages/Noticeboard.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import theme from './../styles/Theme';
 import Post from './../components/noticeboard/Post';
-import Header from '../components/header/Header';
 import Tab from '../components/header/Tab';
 import Restaurant from '../components/noticeboard/Restaurant';
 
@@ -31,7 +30,6 @@ function Noticeboard() {
 
   return (
     <NoticeBoardContainer>
-      <Header background={true} />
       <Tab
         ancestorMenuTree={ancestorMenuTree}
         currentTabContents={currentTabContents}
@@ -57,7 +55,7 @@ export default Noticeboard;
 
 const NoticeBoardContainer = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `;
 
 const BoardBox = styled.div`

--- a/frontend/src/pages/Signup.js
+++ b/frontend/src/pages/Signup.js
@@ -9,7 +9,6 @@ import { useNavigate } from 'react-router-dom';
 import useAlert from '../hook/useAlert';
 import ConfirmMessage from '../constants/ConfirmMessage';
 import { request } from '../utils/axios';
-import Header from '../components/header/Header';
 import Title from '../components/header/Title';
 import { useRecoilValue } from 'recoil';
 import agree from '../atom/agree';
@@ -76,7 +75,6 @@ function Signup(props) {
 
   return (
     <SignupContainer>
-      <Header background={true} />
       <Title titleName="회원가입" />
       <InputForm onSubmit={handleSubmit(onSubmit)}>
         <JoinAnnouncementMent>모든 항목에 응답해주세요</JoinAnnouncementMent>
@@ -183,7 +181,7 @@ export default Signup;
 
 const SignupContainer = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `;
 
 const InputForm = styled.form`

--- a/frontend/src/pages/TOS.js
+++ b/frontend/src/pages/TOS.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import theme from '../styles/Theme';
-import Header from '../components/header/Header';
 import Title from '../components/header/Title';
 import Checkbox from '../components/util/Checkbox';
 import { TOSMessage } from '../constants/TOSMessage';
@@ -47,7 +46,6 @@ function TOS() {
 
   return (
     <TOSContainer>
-      <Header background={true} />
       <Title titleName="회원가입" />
       <HeadNumber>
         {`아직 HICC의 회원이 아닌 경우, 홈페이지 회원가입에 앞서 회장에게 연락하고
@@ -86,7 +84,7 @@ export default TOS;
 
 const TOSContainer = styled.div`
   width: ${theme.componentSize.maxWidth};
-  height: 100vh;
+  height: 100%;
   margin: 0 auto;
 `;
 

--- a/frontend/src/pages/UmbrellaRent.js
+++ b/frontend/src/pages/UmbrellaRent.js
@@ -12,7 +12,6 @@ import {
 import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import ApplyModal from '../components/popup/ApplyModal';
 import moment from 'moment';
-import Header from '../components/header/Header';
 import Navigation from '../components/header/Navigation';
 import useFetch from '../hook/useFetch';
 import { user } from '../atom/user';
@@ -65,7 +64,6 @@ export default function UmbrellaRent(props) {
 
   return (
     <UmbrellaRentContainer>
-      <Header background={true} />
       <Navigation
         ancestorMenuTree={ancestorMenuTree}
         currentTabContents={currentTabContents}
@@ -107,7 +105,7 @@ export default function UmbrellaRent(props) {
 
 const UmbrellaRentContainer = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
 `;
 
 const UmbrellaCurrentState = styled.div`

--- a/frontend/src/pages/UmbrellaRent.js
+++ b/frontend/src/pages/UmbrellaRent.js
@@ -15,6 +15,7 @@ import moment from 'moment';
 import Header from '../components/header/Header';
 import Navigation from '../components/header/Navigation';
 import useFetch from '../hook/useFetch';
+import { user } from '../atom/user';
 
 /*
 currentTabContents는 현재 탭의 정보로
@@ -28,7 +29,7 @@ export default function UmbrellaRent(props) {
   const currentIndex = useRecoilValue(currentUmbrellaIndex); // 현재 인덱스 (모달)
   const resetUmbrella = useResetRecoilState(umbrella); // 우산 상태 초기화
 
-  const myName = '김진호';
+  const userinfo = useRecoilValue(user); // 내 정보 가져오기 위해
 
   const checkMyRent = useMyRent(); // 내가 대여 처리
 
@@ -36,7 +37,7 @@ export default function UmbrellaRent(props) {
 
   useEffect(() => {
     if (data) {
-      const umbrellaListIncludeMyRent = checkMyRent(data, myName);
+      const umbrellaListIncludeMyRent = checkMyRent(data, userinfo.name);
       setInit(umbrellaListIncludeMyRent);
       setUmbrellaList(init);
     }
@@ -90,7 +91,7 @@ export default function UmbrellaRent(props) {
                 <ApplyModal
                   itemName={`우산`}
                   itemNumber={item.umbrellaNumber}
-                  lender={myName}
+                  lender={userinfo.name}
                   startDay={moment(new Date()).format('yyyy-MM-DD')}
                   endDay={moment(sevenDaysAgo).format('yyyy-MM-DD')}
                   startDayDisabled={true}
@@ -142,11 +143,11 @@ const UmbrellaGrid = styled.div`
 const ViewApplyModal = styled.div`
   display: ${props => (props.view ? 'block' : 'none')};
   position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 
-  width: 100vw;
-  height: 100vh;
-  left: 0px;
-  top: 0px;
   background-color: rgba(0, 0, 0, 0.6);
-  z-index: 1;
+  z-index: 101;
 `;

--- a/frontend/src/pages/UmbrellaRent.js
+++ b/frontend/src/pages/UmbrellaRent.js
@@ -45,6 +45,7 @@ export default function UmbrellaRent(props) {
     return () => {
       resetUmbrella();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
   const now = new Date(); //  오늘 날짜
@@ -92,10 +93,8 @@ export default function UmbrellaRent(props) {
                   itemName={`우산`}
                   itemNumber={item.umbrellaNumber}
                   lender={userinfo.name}
-                  startDay={moment(new Date()).format('yyyy-MM-DD')}
-                  endDay={moment(sevenDaysAgo).format('yyyy-MM-DD')}
-                  startDayDisabled={true}
-                  endDayDisabled={true}
+                  startDay={moment(new Date())}
+                  endDay={sevenDaysAgo}
                 />
               ),
           )}

--- a/frontend/src/styles/datepicker.css
+++ b/frontend/src/styles/datepicker.css
@@ -20,12 +20,21 @@
 
 .custom-calender .react-datepicker__day-names {
   background-color: #2c2c33 !important;
+
+  color: rgba(237, 240, 248, 0.70);
+  text-align: center;
+  font-family: 'Pretendard';
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 300;
+  line-height: normal;
 }
 
 .react-datepicker__day-names .react-datepicker__day-name {
-  margin: 0 10px !important;
+  margin: 0 15px !important;
   color: rgba(237, 240, 248, 0.7) !important;
 }
+
 
 .react-datepicker__month {
   margin: 0 !important;
@@ -37,17 +46,24 @@
 }
 
 .react-datepicker__day {
-  margin: 0 10px !important;
+  margin: 5px 15px !important;
   color: #edf0f8 !important;
+
+  text-align: center;
+  font-family: 'Pretendard';
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 300;
+  line-height: normal;
 }
 
 .selectedDay {
   background-color: #4ea1d3 !important;
   border-radius: 50% !important;
-  &:hover {
-    background-color: #4ea1d3 !important;
-    border-radius: 50% !important;
-  }
+}
+
+.selectedDay:hover {
+  border-radius: 50% !important;
 }
 
 .unSelectedDay {
@@ -71,7 +87,7 @@
 
 .react-datepicker__day--today:hover {
   border: 1px solid #4ea1d3;
-  border-radius: 50%;
+  border-radius: 50% !important;
 }
 
 .react-datepicker__children-container {
@@ -79,4 +95,9 @@
   margin: 0 !important;
   padding-right: 0 !important;
   padding-left: 0 !important;
+}
+
+.react-datepicker__day--keyboard-selected {
+  border: none !important;
+  background-color: transparent !important;
 }

--- a/frontend/src/styles/datepickerRent.css
+++ b/frontend/src/styles/datepickerRent.css
@@ -2,6 +2,9 @@
   position: fixed;
 }
 
+.react-datepicker__input-container {
+  width: 0;
+}
 
 .react-datepicker-popper {
   position: fixed !important;
@@ -30,7 +33,7 @@
 }
 
 .react-datepicker__day-names .react-datepicker__day-name {
-  margin: 0 15px !important;
+  margin: 0 14px !important;
   color: rgba(237, 240, 248, 0.7) !important;
 }
 
@@ -46,8 +49,11 @@
 }
 
 .react-datepicker__day {
-  margin: 5px 15px !important;
+  margin: 0 10px !important;
   color: #edf0f8 !important;
+  width: 35px;
+  height: 35px;
+  padding-top: 5px;
 
   text-align: center;
   font-family: 'Pretendard';


### PR DESCRIPTION
# Design: 페이지 레이아웃 파일 생성

## 주요 변경 내용
- 레이아웃 파일을 생성하여 모든 페이지에 헤더와 푸터가 자동으로 들어가게 설정했습니다.
- App.js를 다시 생성했으며, Routes.js파일이 사라졌습니다.

## 참고 사항
-

## 남은 작업 내용
- 다음은 타이포그래피 가이드를 만들어 사용하는 폰트 통일과, theme.js에 폰트스타일을 적용하여 코드를 줄이는 작업을 진행하겠습니다.

## 참고용 시연 사진
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/d97bc3b5-012c-4f59-b43a-f8cf9c3ac6ca)
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/32f4a035-677b-4c70-83f9-675a12531d55)
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/188bdadd-9e8c-479a-b9ab-88add4830e17)
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/f868ea4f-d87e-4429-a537-6a9fd9efe96b)

