### PR TITLE
feat: 맛집 작성 폼 생성 및 등록 시 리뷰 작성 활성화

### DIFF
--- a/frontend/src/components/input/WriteReview.js
+++ b/frontend/src/components/input/WriteReview.js
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import theme from '../../styles/Theme';
+import StarRating from '../util/StarRating';
+import Button from '../util/Button';
+
+function WriteReview() {
+  const [star, setStar] = useState(0);
+
+  return (
+    <>
+      <Container>
+        <UserInfo>
+          <User src="/images/logo.png" />
+          <Nickname>홍길동</Nickname>
+        </UserInfo>
+        <WriteContent>
+          <StarRating
+            edit={true}
+            value={star}
+            isHalf={true}
+            onChange={setStar}
+            color={theme.colors.white}
+          />
+          <Content placeholder="리뷰 내용을 입력하세요." />
+        </WriteContent>
+      </Container>
+      <EnrollButton buttonName="등록" />
+    </>
+  );
+}
+
+export default WriteReview;
+
+const Container = styled.div`
+  display: flex;
+  width: 550px;
+  min-height: 141px;
+  margin-bottom: 10px;
+  padding: 15px;
+
+  background-color: transparent;
+  border-radius: 20px;
+  border: 1px solid ${theme.colors.white};
+`;
+
+const UserInfo = styled.div`
+  width: 85px;
+  margin-right: 8px;
+`;
+
+const User = styled.img`
+  width: 85px;
+  height: 85px;
+  margin-bottom: 6px;
+  border-radius: 50%;
+`;
+
+const Nickname = styled.div`
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  font-weight: 300;
+  text-align: center;
+`;
+
+const WriteContent = styled.div`
+  width: 100%;
+`;
+
+const Content = styled.textarea`
+  width: 100%;
+  min-height: 63px;
+  margin-top: 12px;
+  padding: 0 10px;
+
+  background-color: transparent;
+  border: 1px solid ${theme.colors.blue};
+
+  color: ${theme.colors.white};
+  font-family: 'Pretendard';
+  font-size: ${theme.fontSizes.paragraph};
+  line-height: 150%;
+  resize: none;
+  outline: none;
+
+  &::placeholder {
+    color: ${theme.colors.white};
+    font-family: 'Pretendard';
+    font-size: 20px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 150%;
+  }
+`;
+
+const EnrollButton = styled(Button)`
+  width: 100%;
+  height: 40px;
+
+  margin-bottom: 20px;
+`;

--- a/frontend/src/components/popup/EnrollRestaurant.js
+++ b/frontend/src/components/popup/EnrollRestaurant.js
@@ -6,10 +6,11 @@ import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import EachSearchResult from '../eachItem/EachSearchResult';
 import useInput from './../../hook/useInput';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import curEnrollRestaurant from '../../atom/curEnrollRestaurant';
 import useScrollGradient from '../../hook/useScrollGradient';
 import useCloseModal from '../../hook/useCloseModal';
+import placeId from '../../atom/placeId';
 
 function EnrollRestaurant(props) {
   const { kakao } = window;
@@ -17,6 +18,7 @@ function EnrollRestaurant(props) {
   const [places, setPlaces] = useState([]);
   const [keyword, setKeyword] = useInput('');
   const [current, setCurrent] = useRecoilState(curEnrollRestaurant);
+  const setSelectPlaceId = useSetRecoilState(placeId);
 
   const modalRef = useRef(null);
   useCloseModal(modalRef, props.close);
@@ -53,6 +55,12 @@ function EnrollRestaurant(props) {
   const markerClick = (place, marker) => {
     map.panTo(marker.getPosition());
     setCurrent(place);
+  };
+
+  const selectPlace = () => {
+    setSelectPlaceId(current.id);
+    props.close();
+    props.writeMode(true);
   };
 
   useEffect(() => {
@@ -93,7 +101,7 @@ function EnrollRestaurant(props) {
               />
             ))}
         </SearchList>
-        <EnrollButton>장소 선택</EnrollButton>
+        <EnrollButton onClick={selectPlace}>장소 선택</EnrollButton>
       </SearchSection>
       <MapSection>
         <Map

--- a/frontend/src/components/util/StarRating.js
+++ b/frontend/src/components/util/StarRating.js
@@ -18,7 +18,7 @@ function StarRating(props) {
       size={30}
       half={props.isHalf}
       color1="rgba(0, 0, 0, 0.2)"
-      color2={theme.colors.blue}
+      color2={props.color !== undefined ? props.color : theme.colors.blue}
     />
   );
 }

--- a/frontend/src/pages/Noticeboard.js
+++ b/frontend/src/pages/Noticeboard.js
@@ -60,6 +60,6 @@ const NoticeBoardContainer = styled.div`
 
 const BoardBox = styled.div`
   width: ${theme.componentSize.maxWidth};
-  height: 100vh;
+  height: 100%;
   margin: 0 auto;
 `;


### PR DESCRIPTION
# feat: 맛집 작성 폼 생성 및 등록 시 리뷰 작성 활성화

## 주요 변경 내용
- 맛집 리뷰 등록 폼을 생성했습니다.
- 장소를 선택하지 않고 등록 시 경고창을 뜨게 만들었습니다.
- 맛집 등록에서 선택을 누르면 바로 리뷰 작성으로 넘어가도록 설정했습니다.

## 참고 사항
-

## 남은 작업 내용
- 전체적으로 스타일 통일 작업에 들어갈 예정입니다.

## 참고용 시연 사진
-
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/fd52694d-e79d-4a9e-9d88-269e7de33c8b)
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/ef90e5e2-f0d6-46a4-9352-3af0690126c2)
![image](https://github.com/HICC-WebsiteProduction/HICC-Website-Production-Frontend/assets/81083461/a0a73399-a19d-43b6-b99a-e1dedf3aca1e)

